### PR TITLE
通知の期限切れステータスをFirestore rulesで許可する

### DIFF
--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -310,7 +310,7 @@ service cloud.firestore {
         return data.type in ['friend', 'groupInvitation', 'reaction', 'comment']
           && data.sendUserId is string
           && data.receiveUserId is string
-          && data.status in ['pending', 'accepted', 'rejected']
+          && data.status in ['pending', 'accepted', 'rejected', 'expired']
           && data.createdAt is timestamp
           && data.isRead is bool
           && data.rejectionCount is number

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -287,6 +287,34 @@ describe('Notifications Collection Security Rules', () => {
       );
     });
 
+    test('受信者は友達申請通知を期限切れとして既読にできる', async () => {
+      const mockData = {
+        'notifications/notif1': {
+          type: 'friend',
+          sendUserId: 'user1',
+          receiveUserId: 'user2',
+          status: 'pending',
+          createdAt: new Date(),
+          isRead: false,
+          rejectionCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectSuccess(
+        db.doc('notifications/notif1').update({
+          status: 'expired',
+          isRead: true,
+          updatedAt: new Date()
+        })
+      );
+    });
+
     test('関係のないユーザーは通知を更新できない', async () => {
       const mockData = {
         'notifications/notif1': {


### PR DESCRIPTION
## 概要

Flutter側で退会済みユーザーからの友達申請を処理不能として扱うため、notifications.status に expired を許可します。

## 変更内容

- Firestore rules の notifications.status 許可リストに expired を追加
- 受信者が友達申請通知を expired + isRead に更新できるrulesテストを追加

## 関連

- Flutter側PR: https://github.com/keishimizu26629/LaKiite-flutter-app/pull/160
- Flutter側の expireNotification() が status: expired を書き込むため、このrules更新が必要です。

## 確認

- git diff --check: OK
- npm run emulator:test:ci: 未完了
  - ローカルJavaが17のため、Firebase Emulator起動前に firebase-tools の Java 21 要件で失敗しました。
  - エラー: firebase-tools no longer supports Java version before 21.
