### PR TITLE
退会済みユーザー参照を削除時にクリーンアップする

### DIFF
--- a/functions/src/handlers/user/deletion-cleanup.ts
+++ b/functions/src/handlers/user/deletion-cleanup.ts
@@ -1,5 +1,8 @@
 import * as admin from "firebase-admin";
 
+/**
+ * 退会済みユーザーとして画面に表示する匿名化後の表示名。
+ */
 export const retiredUserDisplayName = "退会済みユーザー";
 
 interface NotificationSnapshot {
@@ -7,6 +10,9 @@ interface NotificationSnapshot {
   status?: string;
 }
 
+/**
+ * コメント・リアクションに保存された投稿者スナップショットを匿名化する更新値を返す。
+ */
 export function buildRetiredUserProfileUpdate() {
   return {
     userDisplayName: retiredUserDisplayName,
@@ -14,6 +20,11 @@ export function buildRetiredUserProfileUpdate() {
   };
 }
 
+/**
+ * 削除ユーザーが送信者になっている通知を匿名化する更新値を返す。
+ *
+ * 未処理の友達申請は、承認できない状態として既読の期限切れ通知へ更新する。
+ */
 export function buildRetiredUserNotificationUpdate(
   notification: NotificationSnapshot
 ) {
@@ -29,10 +40,19 @@ export function buildRetiredUserNotificationUpdate(
   return updateData;
 }
 
+/**
+ * friends配列から退会済みユーザーIDだけを取り除く。
+ */
 export function removeRetiredUserId(friendIds: string[], retiredUserId: string) {
   return friendIds.filter((friendId) => friendId !== retiredUserId);
 }
 
+/**
+ * ユーザー削除後も画面に残り得る参照を退会済みユーザー表示へ寄せる。
+ *
+ * 既存データの一括移行ではなく、削除イベントを起点に関連する表示スナップショットと
+ * 友達関係をクリーンアップする。
+ */
 export async function cleanupRetiredUserReferences(userId: string) {
   await Promise.all([
     anonymizeCollectionGroup("reactions", userId),

--- a/functions/src/handlers/user/deletion-cleanup.ts
+++ b/functions/src/handlers/user/deletion-cleanup.ts
@@ -1,0 +1,108 @@
+import * as admin from "firebase-admin";
+
+export const retiredUserDisplayName = "退会済みユーザー";
+
+interface NotificationSnapshot {
+  type?: string;
+  status?: string;
+}
+
+export function buildRetiredUserProfileUpdate() {
+  return {
+    userDisplayName: retiredUserDisplayName,
+    userPhotoUrl: null,
+  };
+}
+
+export function buildRetiredUserNotificationUpdate(
+  notification: NotificationSnapshot
+) {
+  const updateData: Record<string, string | boolean> = {
+    sendUserDisplayName: retiredUserDisplayName,
+  };
+
+  if (notification.type === "friend" && notification.status === "pending") {
+    updateData.status = "expired";
+    updateData.isRead = true;
+  }
+
+  return updateData;
+}
+
+export function removeRetiredUserId(friendIds: string[], retiredUserId: string) {
+  return friendIds.filter((friendId) => friendId !== retiredUserId);
+}
+
+export async function cleanupRetiredUserReferences(userId: string) {
+  await Promise.all([
+    anonymizeCollectionGroup("reactions", userId),
+    anonymizeCollectionGroup("comments", userId),
+    anonymizeSentNotifications(userId),
+    removeFromFriendLists(userId),
+  ]);
+}
+
+async function anonymizeCollectionGroup(collectionId: string, userId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collectionGroup(collectionId)
+    .where("userId", "==", userId)
+    .get();
+
+  await commitBatches(snapshot.docs, (batch, doc) => {
+    batch.update(doc.ref, buildRetiredUserProfileUpdate());
+  });
+}
+
+async function anonymizeSentNotifications(userId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collection("notifications")
+    .where("sendUserId", "==", userId)
+    .get();
+
+  await commitBatches(snapshot.docs, (batch, doc) => {
+    batch.update(doc.ref, buildRetiredUserNotificationUpdate(doc.data()));
+  });
+}
+
+async function removeFromFriendLists(userId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collectionGroup("private")
+    .where("friends", "array-contains", userId)
+    .get();
+
+  const profileDocs = snapshot.docs.filter((doc) => doc.id === "profile");
+  await commitBatches(profileDocs, (batch, doc) => {
+    batch.update(doc.ref, {
+      friends: admin.firestore.FieldValue.arrayRemove(userId),
+    });
+  });
+}
+
+async function commitBatches<T>(
+  docs: T[],
+  apply: (batch: admin.firestore.WriteBatch, doc: T) => void
+) {
+  const batches: admin.firestore.WriteBatch[] = [];
+  let currentBatch = admin.firestore().batch();
+  let operationCount = 0;
+
+  docs.forEach((doc) => {
+    apply(currentBatch, doc);
+    operationCount++;
+
+    if (operationCount >= 500) {
+      batches.push(currentBatch);
+      currentBatch = admin.firestore().batch();
+      operationCount = 0;
+    }
+  });
+
+  if (operationCount > 0) {
+    batches.push(currentBatch);
+  }
+
+  await Promise.all(batches.map((batch) => batch.commit()));
+}

--- a/functions/src/handlers/user/triggers.ts
+++ b/functions/src/handlers/user/triggers.ts
@@ -1,5 +1,6 @@
 import * as functions from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
+import { cleanupRetiredUserReferences } from "./deletion-cleanup";
 
 /**
  * ユーザー情報更新時に履歴を記録
@@ -71,6 +72,28 @@ export const onUserUpdate = functions.onDocumentUpdated(
     } catch (error) {
       console.error("ユーザー更新履歴記録エラー:", error);
       // エラーが発生してもトリガーは失敗させない
+    }
+  }
+);
+
+/**
+ * ユーザー削除時に、画面に残る参照を退会済みユーザーとして扱える状態へ更新
+ */
+export const onUserDeleted = functions.onDocumentDeleted(
+  {
+    document: "users/{userId}",
+    region: "asia-northeast1",
+    memory: "1GiB",
+    timeoutSeconds: 540,
+  },
+  async (event) => {
+    try {
+      const userId = event.params.userId;
+      await cleanupRetiredUserReferences(userId);
+      console.log(`退会済みユーザー参照のクリーンアップ完了: ${userId}`);
+    } catch (error) {
+      console.error("退会済みユーザー参照のクリーンアップエラー:", error);
+      throw error;
     }
   }
 );

--- a/functions/src/handlers/user/triggers.ts
+++ b/functions/src/handlers/user/triggers.ts
@@ -77,7 +77,10 @@ export const onUserUpdate = functions.onDocumentUpdated(
 );
 
 /**
- * ユーザー削除時に、画面に残る参照を退会済みユーザーとして扱える状態へ更新
+ * ユーザー削除時に、画面に残る参照を退会済みユーザーとして扱える状態へ更新する。
+ *
+ * コメント・リアクション・通知に残る表示用スナップショットを匿名化し、
+ * 他ユーザーのfriends配列から削除済みユーザーIDを取り除く。
  */
 export const onUserDeleted = functions.onDocumentDeleted(
   {

--- a/functions/src/test/user-deletion-cleanup.test.ts
+++ b/functions/src/test/user-deletion-cleanup.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+
+describe("User Deletion Cleanup", () => {
+  describe("buildRetiredUserProfileUpdate", () => {
+    it("should anonymize display name and remove photo url", async () => {
+      const { buildRetiredUserProfileUpdate } = await import(
+        "../handlers/user/deletion-cleanup"
+      );
+
+      expect(buildRetiredUserProfileUpdate()).to.deep.equal({
+        userDisplayName: "退会済みユーザー",
+        userPhotoUrl: null,
+      });
+    });
+  });
+
+  describe("buildRetiredUserNotificationUpdate", () => {
+    it("should anonymize sender display name and expire pending friend requests", async () => {
+      const { buildRetiredUserNotificationUpdate } = await import(
+        "../handlers/user/deletion-cleanup"
+      );
+
+      expect(
+        buildRetiredUserNotificationUpdate({
+          type: "friend",
+          status: "pending",
+        })
+      ).to.deep.equal({
+        sendUserDisplayName: "退会済みユーザー",
+        status: "expired",
+        isRead: true,
+      });
+    });
+
+    it("should only anonymize non-pending notifications", async () => {
+      const { buildRetiredUserNotificationUpdate } = await import(
+        "../handlers/user/deletion-cleanup"
+      );
+
+      expect(
+        buildRetiredUserNotificationUpdate({
+          type: "comment",
+          status: "accepted",
+        })
+      ).to.deep.equal({
+        sendUserDisplayName: "退会済みユーザー",
+      });
+    });
+  });
+
+  describe("removeRetiredUserId", () => {
+    it("should remove retired user id from friend ids", async () => {
+      const { removeRetiredUserId } = await import(
+        "../handlers/user/deletion-cleanup"
+      );
+
+      expect(
+        removeRetiredUserId(["user-1", "deleted-user", "user-2"], "deleted-user")
+      ).to.deep.equal(["user-1", "user-2"]);
+    });
+  });
+});

--- a/functions/src/test/user-triggers.test.ts
+++ b/functions/src/test/user-triggers.test.ts
@@ -10,4 +10,13 @@ describe("User Triggers", () => {
       expect(typeof onUserUpdate).to.equal("function");
     });
   });
+
+  describe("onUserDeleted", () => {
+    it("should be importable", async () => {
+      const { onUserDeleted } = await import("../handlers/user/triggers");
+
+      expect(onUserDeleted).to.not.be.undefined;
+      expect(typeof onUserDeleted).to.equal("function");
+    });
+  });
 });


### PR DESCRIPTION
## 概要

ユーザー削除時に、画面に残る参照を「退会済みユーザー」として扱えるようにクリーンアップするCloud Functionを追加します。

## 変更内容

- `onUserDeleted` トリガーを追加
- 削除ユーザーの reactions/comments を匿名化
  - `userDisplayName`: `退会済みユーザー`
  - `userPhotoUrl`: `null`
- 削除ユーザーが送信者の notifications を匿名化
  - `sendUserDisplayName`: `退会済みユーザー`
- pending の friend 通知は `expired + isRead` に更新
- 他ユーザーの `friends` 配列から削除ユーザーIDを除去
- 更新データ生成の単体テストとトリガーimportテストを追加

## 関連

- Flutter側PR: https://github.com/keishimizu26629/LaKiite-flutter-app/pull/161

## 注意

- このPRは削除時点以降のクリーンアップを対象にします。
- 既存の過去データを一括匿名化するmigrationは別タスクです。

## 確認

- `npm run test:node20`

