### PR TITLE
ユーザープロフィール表示情報を即時同期する

### DIFF
--- a/functions/src/handlers/user/batch-sync.ts
+++ b/functions/src/handlers/user/batch-sync.ts
@@ -1,5 +1,6 @@
 import * as functions from "firebase-functions/v2/scheduler";
 import * as admin from "firebase-admin";
+import { syncUserProfileSnapshots } from "./profile-sync";
 
 export interface UserUpdateData {
   id: string;
@@ -100,11 +101,8 @@ export async function processUserUpdates(userId: string, updates: UserUpdateData
 
     console.log(`ユーザー ${userId} の最新更新:`, latestUpdates);
 
-    // バッチ処理でリアクション・コメントを更新
-    await Promise.all([
-      updateReactions(userId, latestUpdates),
-      updateComments(userId, latestUpdates),
-    ]);
+    // バッチ処理で表示用スナップショットを更新
+    await syncUserProfileSnapshots(userId, latestUpdates);
 
     // 処理完了をマーク
     await markAsProcessed(updates);
@@ -116,116 +114,6 @@ export async function processUserUpdates(userId: string, updates: UserUpdateData
     await incrementRetryCount(updates, errorMessage);
     throw error;
   }
-}
-
-/**
- * リアクションデータの更新
- */
-async function updateReactions(
-  userId: string,
-  latestUpdates: Record<string, string>
-) {
-  const reactionQuery = await admin
-    .firestore()
-    .collectionGroup("reactions")
-    .where("userId", "==", userId)
-    .get();
-
-  if (reactionQuery.empty) {
-    console.log(`ユーザー ${userId}: 更新対象のリアクションなし`);
-    return;
-  }
-
-  console.log(`ユーザー ${userId}: ${reactionQuery.size}件のリアクションを更新`);
-
-  const batches: admin.firestore.WriteBatch[] = [];
-  let currentBatch = admin.firestore().batch();
-  let operationCount = 0;
-
-  reactionQuery.docs.forEach((doc) => {
-    const updateData: Record<string, string> = {};
-
-    if (latestUpdates.displayName) {
-      updateData.userDisplayName = latestUpdates.displayName;
-    }
-    if (latestUpdates.iconUrl) {
-      updateData.userPhotoUrl = latestUpdates.iconUrl;
-    }
-
-    if (Object.keys(updateData).length > 0) {
-      currentBatch.update(doc.ref, updateData);
-      operationCount++;
-
-      // Firestoreのバッチ制限（500操作）に達したら新しいバッチを作成
-      if (operationCount >= 500) {
-        batches.push(currentBatch);
-        currentBatch = admin.firestore().batch();
-        operationCount = 0;
-      }
-    }
-  });
-
-  if (operationCount > 0) {
-    batches.push(currentBatch);
-  }
-
-  // 全バッチを並列実行
-  await Promise.all(batches.map((batch) => batch.commit()));
-  console.log(`${userId} のリアクション ${reactionQuery.size} 件を更新完了`);
-}
-
-/**
- * コメントデータの更新
- */
-async function updateComments(
-  userId: string,
-  latestUpdates: Record<string, string>
-) {
-  const commentQuery = await admin
-    .firestore()
-    .collectionGroup("comments")
-    .where("userId", "==", userId)
-    .get();
-
-  if (commentQuery.empty) {
-    console.log(`ユーザー ${userId}: 更新対象のコメントなし`);
-    return;
-  }
-
-  console.log(`ユーザー ${userId}: ${commentQuery.size}件のコメントを更新`);
-
-  const batches: admin.firestore.WriteBatch[] = [];
-  let currentBatch = admin.firestore().batch();
-  let operationCount = 0;
-
-  commentQuery.docs.forEach((doc) => {
-    const updateData: Record<string, string> = {};
-
-    if (latestUpdates.displayName) {
-      updateData.userDisplayName = latestUpdates.displayName;
-    }
-    if (latestUpdates.iconUrl) {
-      updateData.userPhotoUrl = latestUpdates.iconUrl;
-    }
-
-    if (Object.keys(updateData).length > 0) {
-      currentBatch.update(doc.ref, updateData);
-      operationCount++;
-
-      if (operationCount >= 500) {
-        batches.push(currentBatch);
-        currentBatch = admin.firestore().batch();
-        operationCount = 0;
-      }
-    }
-  });
-
-  if (operationCount > 0) {
-    batches.push(currentBatch);
-  }
-
-  await Promise.all(batches.map((batch) => batch.commit()));
-  console.log(`${userId} のコメント ${commentQuery.size} 件を更新完了`);
 }
 
 /**

--- a/functions/src/handlers/user/profile-sync.ts
+++ b/functions/src/handlers/user/profile-sync.ts
@@ -1,0 +1,255 @@
+import * as admin from "firebase-admin";
+
+export interface UserProfileSnapshot {
+  displayName?: string | null;
+  iconUrl?: string | null;
+}
+
+export interface BuildUserProfileUpdatesInput {
+  userId: string;
+  before: UserProfileSnapshot;
+  after: UserProfileSnapshot;
+  updatedAt: Date;
+}
+
+export interface UserProfileUpdateData {
+  id: string;
+  userId: string;
+  fieldName: "displayName" | "iconUrl";
+  oldValue: string;
+  newValue: string;
+  updatedAt: Date;
+  isProcessed: boolean;
+  retryCount: number;
+}
+
+interface NotificationSnapshot {
+  sendUserId?: string;
+  receiveUserId?: string;
+}
+
+interface BuildNotificationSnapshotUpdateInput {
+  userId: string;
+  notification: NotificationSnapshot;
+  latestUpdates: Record<string, string>;
+}
+
+/**
+ * users/{userId} の変更前後から、同期対象のプロフィール更新履歴を生成する。
+ */
+export function buildUserProfileUpdates({
+  userId,
+  before,
+  after,
+  updatedAt,
+}: BuildUserProfileUpdatesInput): UserProfileUpdateData[] {
+  const timestamp = updatedAt.getTime();
+  const updates: UserProfileUpdateData[] = [];
+
+  if (before.displayName !== after.displayName) {
+    updates.push({
+      id: `${userId}_displayName_${timestamp}`,
+      userId,
+      fieldName: "displayName",
+      oldValue: before.displayName || "",
+      newValue: after.displayName || "",
+      updatedAt,
+      isProcessed: false,
+      retryCount: 0,
+    });
+  }
+
+  if (before.iconUrl !== after.iconUrl) {
+    updates.push({
+      id: `${userId}_iconUrl_${timestamp}`,
+      userId,
+      fieldName: "iconUrl",
+      oldValue: before.iconUrl || "",
+      newValue: after.iconUrl || "",
+      updatedAt,
+      isProcessed: false,
+      retryCount: 0,
+    });
+  }
+
+  return updates;
+}
+
+/**
+ * コメント・リアクションに保存された投稿者スナップショットの更新値を返す。
+ */
+export function buildProfileSnapshotUpdate(
+  latestUpdates: Record<string, string>
+) {
+  const updateData: Record<string, string> = {};
+
+  if (hasUpdateField(latestUpdates, "displayName")) {
+    updateData.userDisplayName = latestUpdates.displayName;
+  }
+  if (hasUpdateField(latestUpdates, "iconUrl")) {
+    updateData.userPhotoUrl = latestUpdates.iconUrl;
+  }
+
+  return updateData;
+}
+
+/**
+ * 予定に保存された所有者スナップショットの更新値を返す。
+ */
+export function buildScheduleOwnerSnapshotUpdate(
+  latestUpdates: Record<string, string>
+) {
+  const updateData: Record<string, string> = {};
+
+  if (hasUpdateField(latestUpdates, "displayName")) {
+    updateData.ownerDisplayName = latestUpdates.displayName;
+  }
+  if (hasUpdateField(latestUpdates, "iconUrl")) {
+    updateData.ownerPhotoUrl = latestUpdates.iconUrl;
+  }
+
+  return updateData;
+}
+
+/**
+ * 通知に保存された送信者・受信者表示名スナップショットの更新値を返す。
+ */
+export function buildNotificationSnapshotUpdate({
+  userId,
+  notification,
+  latestUpdates,
+}: BuildNotificationSnapshotUpdateInput) {
+  const updateData: Record<string, string> = {};
+
+  if (!hasUpdateField(latestUpdates, "displayName")) {
+    return updateData;
+  }
+
+  if (notification.sendUserId === userId) {
+    updateData.sendUserDisplayName = latestUpdates.displayName;
+  }
+  if (notification.receiveUserId === userId) {
+    updateData.receiveUserDisplayName = latestUpdates.displayName;
+  }
+
+  return updateData;
+}
+
+function hasUpdateField(
+  latestUpdates: Record<string, string>,
+  fieldName: string
+) {
+  return Object.prototype.hasOwnProperty.call(latestUpdates, fieldName);
+}
+
+/**
+ * ユーザープロフィール変更を、画面に残る表示用スナップショットへ同期する。
+ */
+export async function syncUserProfileSnapshots(
+  userId: string,
+  latestUpdates: Record<string, string>
+) {
+  await Promise.all([
+    updateCollectionGroupSnapshots("reactions", userId, latestUpdates),
+    updateCollectionGroupSnapshots("comments", userId, latestUpdates),
+    updateScheduleOwnerSnapshots(userId, latestUpdates),
+    updateNotificationSnapshots(userId, latestUpdates),
+  ]);
+}
+
+async function updateCollectionGroupSnapshots(
+  collectionId: string,
+  userId: string,
+  latestUpdates: Record<string, string>
+) {
+  const updateData = buildProfileSnapshotUpdate(latestUpdates);
+  if (Object.keys(updateData).length === 0) {
+    return;
+  }
+
+  const snapshot = await admin
+    .firestore()
+    .collectionGroup(collectionId)
+    .where("userId", "==", userId)
+    .get();
+
+  await commitBatches(snapshot.docs, (batch, doc) => {
+    batch.update(doc.ref, updateData);
+  });
+}
+
+async function updateScheduleOwnerSnapshots(
+  userId: string,
+  latestUpdates: Record<string, string>
+) {
+  const updateData = buildScheduleOwnerSnapshotUpdate(latestUpdates);
+  if (Object.keys(updateData).length === 0) {
+    return;
+  }
+
+  const snapshot = await admin
+    .firestore()
+    .collection("schedules")
+    .where("ownerId", "==", userId)
+    .get();
+
+  await commitBatches(snapshot.docs, (batch, doc) => {
+    batch.update(doc.ref, updateData);
+  });
+}
+
+async function updateNotificationSnapshots(
+  userId: string,
+  latestUpdates: Record<string, string>
+) {
+  if (!hasUpdateField(latestUpdates, "displayName")) {
+    return;
+  }
+
+  const [sentSnapshot, receivedSnapshot] = await Promise.all([
+    admin.firestore().collection("notifications").where("sendUserId", "==", userId).get(),
+    admin.firestore().collection("notifications").where("receiveUserId", "==", userId).get(),
+  ]);
+  const docsById = new Map<string, admin.firestore.QueryDocumentSnapshot>();
+
+  sentSnapshot.docs.forEach((doc) => docsById.set(doc.id, doc));
+  receivedSnapshot.docs.forEach((doc) => docsById.set(doc.id, doc));
+
+  await commitBatches(Array.from(docsById.values()), (batch, doc) => {
+    const updateData = buildNotificationSnapshotUpdate({
+      userId,
+      notification: doc.data(),
+      latestUpdates,
+    });
+
+    if (Object.keys(updateData).length > 0) {
+      batch.update(doc.ref, updateData);
+    }
+  });
+}
+
+async function commitBatches<T>(
+  docs: T[],
+  apply: (batch: admin.firestore.WriteBatch, doc: T) => void
+) {
+  const batches: admin.firestore.WriteBatch[] = [];
+  let currentBatch = admin.firestore().batch();
+  let operationCount = 0;
+
+  docs.forEach((doc) => {
+    apply(currentBatch, doc);
+    operationCount++;
+
+    if (operationCount >= 500) {
+      batches.push(currentBatch);
+      currentBatch = admin.firestore().batch();
+      operationCount = 0;
+    }
+  });
+
+  if (operationCount > 0) {
+    batches.push(currentBatch);
+  }
+
+  await Promise.all(batches.map((batch) => batch.commit()));
+}

--- a/functions/src/handlers/user/triggers.ts
+++ b/functions/src/handlers/user/triggers.ts
@@ -1,6 +1,8 @@
 import * as functions from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
 import { cleanupRetiredUserReferences } from "./deletion-cleanup";
+import { processUserUpdates } from "./batch-sync";
+import { buildUserProfileUpdates } from "./profile-sync";
 
 /**
  * ユーザー情報更新時に履歴を記録
@@ -21,54 +23,35 @@ export const onUserUpdate = functions.onDocumentUpdated(
         return;
       }
 
-      const batch = admin.firestore().batch();
-      const now = admin.firestore.FieldValue.serverTimestamp();
-      let hasChanges = false;
+      const updatedAt = new Date();
+      const updates = buildUserProfileUpdates({
+        userId,
+        before,
+        after,
+        updatedAt,
+      });
 
-      // 表示名の変更を検出
-      if (before.displayName !== after.displayName) {
-        const historyRef = admin
-          .firestore()
-          .collection("user_update_history")
-          .doc();
-        batch.set(historyRef, {
-          userId,
-          fieldName: "displayName",
-          oldValue: before.displayName || "",
-          newValue: after.displayName || "",
-          updatedAt: now,
-          isProcessed: false,
-          retryCount: 0,
-        });
-        hasChanges = true;
-        console.log(`表示名変更を検出: ${before.displayName} → ${after.displayName}`);
-      }
-
-      // アイコンURLの変更を検出
-      if (before.iconUrl !== after.iconUrl) {
-        const historyRef = admin
-          .firestore()
-          .collection("user_update_history")
-          .doc();
-        batch.set(historyRef, {
-          userId,
-          fieldName: "iconUrl",
-          oldValue: before.iconUrl || "",
-          newValue: after.iconUrl || "",
-          updatedAt: now,
-          isProcessed: false,
-          retryCount: 0,
-        });
-        hasChanges = true;
-        console.log(`アイコンURL変更を検出: ${before.iconUrl} → ${after.iconUrl}`);
-      }
-
-      if (hasChanges) {
-        await batch.commit();
-        console.log(`ユーザー更新履歴を記録: ${userId}`);
-      } else {
+      if (updates.length === 0) {
         console.log(`関連フィールドの変更なし: ${userId}`);
+        return;
       }
+
+      const batch = admin.firestore().batch();
+      updates.forEach((update) => {
+        const historyRef = admin
+          .firestore()
+          .collection("user_update_history")
+          .doc(update.id);
+        batch.set(historyRef, {
+          ...update,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      });
+      await batch.commit();
+      console.log(`ユーザー更新履歴を記録: ${userId}, ${updates.length}件`);
+
+      await processUserUpdates(userId, updates);
+      console.log(`ユーザープロフィール即時同期完了: ${userId}`);
     } catch (error) {
       console.error("ユーザー更新履歴記録エラー:", error);
       // エラーが発生してもトリガーは失敗させない

--- a/functions/src/test/profile-sync.test.ts
+++ b/functions/src/test/profile-sync.test.ts
@@ -1,0 +1,179 @@
+import { expect } from "chai";
+
+describe("Profile Snapshot Sync", () => {
+  describe("buildUserProfileUpdates", () => {
+    it("should detect display name and icon url changes", async () => {
+      const { buildUserProfileUpdates } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildUserProfileUpdates({
+          userId: "user-1",
+          before: {
+            displayName: "Old Name",
+            iconUrl: "https://example.com/old.jpg",
+          },
+          after: {
+            displayName: "New Name",
+            iconUrl: "https://example.com/new.jpg",
+          },
+          updatedAt: new Date("2026-05-24T00:00:00Z"),
+        })
+      ).to.deep.equal([
+        {
+          id: "user-1_displayName_1779580800000",
+          userId: "user-1",
+          fieldName: "displayName",
+          oldValue: "Old Name",
+          newValue: "New Name",
+          updatedAt: new Date("2026-05-24T00:00:00Z"),
+          isProcessed: false,
+          retryCount: 0,
+        },
+        {
+          id: "user-1_iconUrl_1779580800000",
+          userId: "user-1",
+          fieldName: "iconUrl",
+          oldValue: "https://example.com/old.jpg",
+          newValue: "https://example.com/new.jpg",
+          updatedAt: new Date("2026-05-24T00:00:00Z"),
+          isProcessed: false,
+          retryCount: 0,
+        },
+      ]);
+    });
+
+    it("should return empty updates when profile snapshot fields did not change", async () => {
+      const { buildUserProfileUpdates } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildUserProfileUpdates({
+          userId: "user-1",
+          before: { displayName: "Name", iconUrl: null },
+          after: { displayName: "Name", iconUrl: null },
+          updatedAt: new Date("2026-05-24T00:00:00Z"),
+        })
+      ).to.deep.equal([]);
+    });
+  });
+
+  describe("buildProfileSnapshotUpdate", () => {
+    it("should map displayName and iconUrl to actor snapshot fields", async () => {
+      const { buildProfileSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildProfileSnapshotUpdate({
+          displayName: "New Name",
+          iconUrl: "https://example.com/icon.jpg",
+        })
+      ).to.deep.equal({
+        userDisplayName: "New Name",
+        userPhotoUrl: "https://example.com/icon.jpg",
+      });
+    });
+
+    it("should omit unchanged profile fields", async () => {
+      const { buildProfileSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(buildProfileSnapshotUpdate({ displayName: "New Name" })).to.deep.equal({
+        userDisplayName: "New Name",
+      });
+    });
+
+    it("should preserve empty icon url updates", async () => {
+      const { buildProfileSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(buildProfileSnapshotUpdate({ iconUrl: "" })).to.deep.equal({
+        userPhotoUrl: "",
+      });
+    });
+  });
+
+  describe("buildScheduleOwnerSnapshotUpdate", () => {
+    it("should map profile updates to schedule owner snapshot fields", async () => {
+      const { buildScheduleOwnerSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildScheduleOwnerSnapshotUpdate({
+          displayName: "New Name",
+          iconUrl: "https://example.com/icon.jpg",
+        })
+      ).to.deep.equal({
+        ownerDisplayName: "New Name",
+        ownerPhotoUrl: "https://example.com/icon.jpg",
+      });
+    });
+
+    it("should preserve empty owner icon url updates", async () => {
+      const { buildScheduleOwnerSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(buildScheduleOwnerSnapshotUpdate({ iconUrl: "" })).to.deep.equal({
+        ownerPhotoUrl: "",
+      });
+    });
+  });
+
+  describe("buildNotificationSnapshotUpdate", () => {
+    it("should update sender and receiver display name snapshots independently", async () => {
+      const { buildNotificationSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildNotificationSnapshotUpdate({
+          userId: "user-1",
+          notification: {
+            sendUserId: "user-1",
+            receiveUserId: "user-2",
+          },
+          latestUpdates: { displayName: "New Name" },
+        })
+      ).to.deep.equal({
+        sendUserDisplayName: "New Name",
+      });
+
+      expect(
+        buildNotificationSnapshotUpdate({
+          userId: "user-1",
+          notification: {
+            sendUserId: "user-2",
+            receiveUserId: "user-1",
+          },
+          latestUpdates: { displayName: "New Name" },
+        })
+      ).to.deep.equal({
+        receiveUserDisplayName: "New Name",
+      });
+    });
+
+    it("should return empty update when display name did not change", async () => {
+      const { buildNotificationSnapshotUpdate } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(
+        buildNotificationSnapshotUpdate({
+          userId: "user-1",
+          notification: {
+            sendUserId: "user-1",
+            receiveUserId: "user-2",
+          },
+          latestUpdates: { iconUrl: "https://example.com/icon.jpg" },
+        })
+      ).to.deep.equal({});
+    });
+  });
+});


### PR DESCRIPTION
## 概要
- `users/{userId}` の `displayName` / `iconUrl` 更新時に、表示用スナップショットを即時同期するようにしました。
- コメント・リアクション・予定・通知の表示名スナップショット更新を `profile-sync.ts` に分離しました。
- 既存の `userDataSyncBatch` は fallback / backfill として残し、即時同期処理からも同じ処理経路を使うようにしました。
- プロフィール画像を削除した場合に古い画像 URL が残らないよう、空文字の `iconUrl` 更新も同期対象にしました。

## 背景
- 旧 PR #2 は stale かつ削除処理の責務が混ざっていたため close し、退会済みユーザー処理は #5 で分離済みです。
- 本 PR では、ユーザープロフィール情報の即時同期だけに責務を絞っています。

## テスト
- `npm run test:node20`
  - `22 passing`
- `npm run lint`
  - exit 0
  - 既存の `batch-sync.ts` に `Forbidden non-null assertion` warning が 1 件あります
- `git diff --check`
  - OK
