### PR TITLE
Firebase Hostingのdev/prodデプロイを追加する

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -1,0 +1,58 @@
+name: Firebase Hosting Deploy
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - "public/**"
+      - "firebase.json"
+      - ".firebaserc"
+      - ".github/workflows/firebase-hosting-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Firebase project alias to deploy"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+
+jobs:
+  deploy-hosting:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Resolve Firebase project alias
+        id: project
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "alias=${{ inputs.target }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "alias=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "alias=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy Firebase Hosting
+        run: |
+          firebase deploy \
+            --only hosting \
+            --project "${{ steps.project.outputs.alias }}" \
+            --token "${{ secrets.FIREBASE_TOKEN }}"

--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -11,6 +11,8 @@ on:
       - "package.json"
       - "package-lock.json"
       - "firebase.json"
+      - ".github/workflows/firestore-rules-test.yml"
+      - ".github/workflows/firebase-hosting-deploy.yml"
   pull_request:
     branches: [main, dev]
     paths:
@@ -21,6 +23,8 @@ on:
       - "package.json"
       - "package-lock.json"
       - "firebase.json"
+      - ".github/workflows/firestore-rules-test.yml"
+      - ".github/workflows/firebase-hosting-deploy.yml"
 
 jobs:
   test-rules:

--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -2,7 +2,7 @@ name: Firebase Security and Functions Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - "security_rules/firestore/**"
       - "security_rules/storage/**"
@@ -12,7 +12,7 @@ on:
       - "package-lock.json"
       - "firebase.json"
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "security_rules/firestore/**"
       - "security_rules/storage/**"


### PR DESCRIPTION
## 概要
- GitHub ActionsにFirebase Hosting deploy workflowを追加
- dev branchへのpushでFirebase project alias `dev` へHosting deploy
- main branchへのpushでFirebase project alias `prod` へHosting deploy
- 既存のFirebase Security and Functions Testsの対象branchを `develop` から `dev` に変更

## ブランチ運用
- `dev` を最新mainから作成済み
- GitHub repositoryのdefault branchを `dev` に変更済み
- `main` はprod用branchとして維持

## 確認
- workflow YAML構文チェック済み
- `git diff --check` 済み

## 補足
- GitHub Pages APIは404で、このrepoのPages siteは見つかりませんでした
- Firebase deployには既存の `FIREBASE_TOKEN` secretを利用します