### PR TITLE
[codex] Add friend request acceptance rules coverage

### DIFF
--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -287,6 +287,34 @@ describe('Notifications Collection Security Rules', () => {
       );
     });
 
+    test('受信者は友達申請通知を承認できる', async () => {
+      const mockData = {
+        'notifications/notif1': {
+          type: 'friend',
+          sendUserId: 'user1',
+          receiveUserId: 'user2',
+          status: 'pending',
+          createdAt: new Date(),
+          isRead: false,
+          rejectionCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectSuccess(
+        db.doc('notifications/notif1').update({
+          status: 'accepted',
+          isRead: true,
+          updatedAt: new Date()
+        })
+      );
+    });
+
     test('受信者は友達申請通知を期限切れとして既読にできる', async () => {
       const mockData = {
         'notifications/notif1': {


### PR DESCRIPTION
## Summary
- Add Firestore Rules regression coverage proving a receiver can mark an incoming friend request notification as accepted.
- Covers the server-triggered acceptance model used by the Flutter app fix.
- Make the rules deploy job skip deployment when Firebase deployment secrets are not configured, instead of failing after tests pass.
- Include this workflow file in path filters so future workflow changes trigger CI.

## CI Root Cause
The failing main run reached deploy-rules after tests passed, but FIREBASE_TOKEN and FIREBASE_PROJECT_ID were empty. The deploy command ran as firebase deploy --token "" --project "" and failed authentication.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/firestore-rules-test.yml"); puts "YAML OK"'
- git diff --check
- npm test -- notifications.test.js attempted locally, but local Jest execution is blocked because node_modules/jest-cli is missing its build/index.js entry after npm install on this machine. No package files are included in this PR.
