### PR TITLE
[codex] Skip rules deploy when Firebase secrets are missing

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -254,7 +254,21 @@ jobs:
       - name: Setup Firebase CLI
         run: npm install -g firebase-tools
 
+      - name: Check Firebase deployment secrets
+        id: firebase-secrets
+        run: |
+          if [ -z "$FIREBASE_TOKEN" ] || [ -z "$FIREBASE_PROJECT_ID" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Firebase deployment secrets are not configured. Skipping Firestore Rules deployment."
+          else
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+
       - name: Deploy Firestore Rules
+        if: steps.firebase-secrets.outputs.should_deploy == 'true'
         run: |
           echo "🚀 Firestoreセキュリティルールをデプロイ中..."
           firebase deploy --only firestore:rules --token "${{ secrets.FIREBASE_TOKEN }}" --project "${{ secrets.FIREBASE_PROJECT_ID }}"
@@ -262,3 +276,7 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Skip Firestore Rules deployment
+        if: steps.firebase-secrets.outputs.should_deploy == 'false'
+        run: echo "Firestore Rules deployment skipped because Firebase deployment secrets are not configured."

--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, develop]
     paths:
+      - ".github/workflows/firestore-rules-test.yml"
       - "security_rules/firestore/**"
       - "security_rules/storage/**"
       - "tests/**"
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/workflows/firestore-rules-test.yml"
       - "security_rules/firestore/**"
       - "security_rules/storage/**"
       - "tests/**"


### PR DESCRIPTION
## Summary
- Skip the Firestore Rules deploy step when FIREBASE_TOKEN or FIREBASE_PROJECT_ID are not configured.
- Keep tests and security checks passing while avoiding a false deploy failure on main.
- Add the workflow file itself to the path filters so future workflow-only CI fixes run on PRs and pushes.

## Root Cause
The failed main run executed firebase deploy with empty secrets: --token "" and --project "". Tests had already passed; only deployment authentication failed.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/firestore-rules-test.yml"); puts "YAML OK"'
- git diff --check origin/main..HEAD
