### PR TITLE
[codex] リスト変更時に予定の公開範囲を再計算する

### DIFF
--- a/functions/src/handlers/list/manual-sync.ts
+++ b/functions/src/handlers/list/manual-sync.ts
@@ -1,0 +1,54 @@
+import * as functions from "firebase-functions/v2/https";
+import * as admin from "firebase-admin";
+import { backfillAllScheduleVisibility } from "./utils";
+
+/**
+ * 既存予定の visibleTo を sharedLists の現在メンバーから再計算する手動同期。
+ *
+ * dev の検証と移行作業用。呼び出しには Firebase ID token が必要。
+ * 現状の既存アプリには direct share のUIがないため、owner + list members
+ * を正として再計算する。
+ */
+export const backfillScheduleVisibility = functions.onRequest(
+  {
+    region: "asia-northeast1",
+    cors: true,
+  },
+  async (req, res) => {
+    try {
+      res.set("Access-Control-Allow-Origin", "*");
+      res.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+      res.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+      if (req.method === "OPTIONS") {
+        res.status(204).send("");
+        return;
+      }
+
+      if (req.method !== "POST") {
+        res.status(405).send({ error: "Method Not Allowed" });
+        return;
+      }
+
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        res.status(401).send({ error: "認証が必要です" });
+        return;
+      }
+
+      const token = authHeader.split("Bearer ")[1];
+      await admin.auth().verifyIdToken(token);
+
+      const result = await backfillAllScheduleVisibility();
+      res.status(200).send({
+        success: true,
+        result,
+      });
+    } catch (error) {
+      console.error("Schedule visibility backfill failed:", error);
+      res.status(500).send({
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+);

--- a/functions/src/handlers/list/triggers.ts
+++ b/functions/src/handlers/list/triggers.ts
@@ -1,5 +1,5 @@
-import { onDocumentUpdated } from "firebase-functions/v2/firestore";
-import { updateSchedulesVisibility } from "./utils";
+import { onDocumentDeleted, onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { removeDeletedListFromSchedules, updateSchedulesVisibility } from "./utils";
 
 /**
  * リストのメンバーが変更された時に実行されるトリガー
@@ -44,6 +44,24 @@ export const onListMemberUpdate = onDocumentUpdated({
     console.log(`Successfully updated schedules visibility for list ${listId}`);
   } catch (error) {
     console.error(`Error updating schedules visibility for list ${listId}:`, error);
+    throw error;
+  }
+});
+
+/**
+ * リストが削除された時に、そのリスト経由の予定公開を解除するトリガー
+ */
+export const onListDeleted = onDocumentDeleted({
+  document: "lists/{listId}",
+  region: "asia-northeast1"
+}, async (event) => {
+  const listId = event.params.listId;
+
+  try {
+    await removeDeletedListFromSchedules(listId);
+    console.log(`Successfully removed deleted list ${listId} from schedules`);
+  } catch (error) {
+    console.error(`Error removing deleted list ${listId} from schedules:`, error);
     throw error;
   }
 });

--- a/functions/src/handlers/list/utils.ts
+++ b/functions/src/handlers/list/utils.ts
@@ -1,7 +1,11 @@
 import * as admin from "firebase-admin";
 
 /**
- * リストメンバー変更時に関連する予定の可視性を更新する
+ * リストメンバー変更時に関連する予定の可視性を更新する。
+ *
+ * 差分で visibleTo を足し引きすると、同じユーザーが複数リストから共有
+ * されている場合に誤って閲覧権限を消してしまう。対象予定ごとに
+ * sharedLists の全リストを読み直し、毎回 union を再計算する。
  * @param listId 変更されたリストのID
  * @param addedMembers 追加されたメンバーのIDリスト
  * @param removedMembers 削除されたメンバーのIDリスト
@@ -15,16 +19,82 @@ export async function updateSchedulesVisibility(
   console.log(`Added members: ${addedMembers.join(", ")}`);
   console.log(`Removed members: ${removedMembers.join(", ")}`);
 
-  // 変更がない場合は早期リターン
   if (addedMembers.length === 0 && removedMembers.length === 0) {
     console.log("No member changes detected, skipping update");
     return;
   }
 
+  await recomputeSchedulesVisibilityForList(listId);
+}
+
+/**
+ * リスト削除時に、そのリストを共有元にしている予定から共有を外す。
+ * @param listId 削除されたリストのID
+ */
+export async function removeDeletedListFromSchedules(
+  listId: string
+): Promise<void> {
+  console.log(`Removing deleted list ${listId} from schedules`);
+  await recomputeSchedulesVisibilityForList(listId, { removeListId: listId });
+}
+
+/**
+ * 全予定の visibleTo を再計算する。既存データの backfill 用。
+ */
+export async function backfillAllScheduleVisibility(): Promise<{
+  scanned: number;
+  updated: number;
+}> {
+  const db = admin.firestore();
+  const schedulesSnapshot = await db.collection("schedules").get();
+  let batch = db.batch();
+  let batchCount = 0;
+  let updated = 0;
+
+  for (const scheduleDoc of schedulesSnapshot.docs) {
+    const scheduleData = scheduleDoc.data();
+    const sharedLists = asStringArray(scheduleData.sharedLists);
+
+    if (sharedLists.length === 0) {
+      continue;
+    }
+
+    const nextVisibleTo = await calculateVisibleTo(scheduleData);
+    const currentVisibleTo = asStringArray(scheduleData.visibleTo);
+
+    if (!arraysEqual([...nextVisibleTo].sort(), [...currentVisibleTo].sort())) {
+      batch.update(scheduleDoc.ref, {
+        visibleTo: nextVisibleTo,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+      batchCount++;
+      updated++;
+    }
+
+    if (batchCount >= 450) {
+      await batch.commit();
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  if (batchCount > 0) {
+    await batch.commit();
+  }
+
+  return {
+    scanned: schedulesSnapshot.size,
+    updated,
+  };
+}
+
+async function recomputeSchedulesVisibilityForList(
+  listId: string,
+  options: { removeListId?: string } = {}
+): Promise<void> {
   const db = admin.firestore();
 
   try {
-    // このリストを使用している全ての予定を取得
     const schedulesSnapshot = await db
       .collection("schedules")
       .where("sharedLists", "array-contains", listId)
@@ -37,54 +107,48 @@ export async function updateSchedulesVisibility(
       return;
     }
 
-    const batch = db.batch();
+    let batch = db.batch();
     let batchCount = 0;
     let updatedCount = 0;
 
     for (const scheduleDoc of schedulesSnapshot.docs) {
       const scheduleData = scheduleDoc.data();
-      const currentVisibleToArray = (scheduleData.visibleTo || []) as string[];
-      const currentVisibleTo = new Set<string>(currentVisibleToArray);
-      const originalSize = currentVisibleTo.size;
+      const currentVisibleToArray = asStringArray(scheduleData.visibleTo);
+      const nextScheduleData = removeSharedListFromScheduleData(
+        scheduleData,
+        options.removeListId
+      );
+      const newVisibleTo = await calculateVisibleTo(nextScheduleData);
+      const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
+        visibleTo: newVisibleTo,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      };
 
-      // 追加されたメンバーをvisibleToに追加
-      addedMembers.forEach(memberId => {
-        currentVisibleTo.add(memberId);
-      });
+      if (options.removeListId) {
+        updateData.sharedLists = admin.firestore.FieldValue.arrayRemove(
+          options.removeListId
+        );
+      }
 
-      // 削除されたメンバーをvisibleToから削除（オーナーは除く）
-      removedMembers.forEach(memberId => {
-        if (memberId !== scheduleData.ownerId) {
-          currentVisibleTo.delete(memberId);
-        }
-      });
-
-      // 変更があった場合のみ更新
-      const newVisibleTo = Array.from(currentVisibleTo);
-
-      if (currentVisibleTo.size !== originalSize ||
-          !arraysEqual(newVisibleTo.sort(), currentVisibleToArray.sort())) {
-
-        batch.update(scheduleDoc.ref, {
-          visibleTo: newVisibleTo,
-          updatedAt: admin.firestore.FieldValue.serverTimestamp()
-        });
-
+      if (
+        !arraysEqual([...newVisibleTo].sort(), [...currentVisibleToArray].sort()) ||
+        options.removeListId
+      ) {
+        batch.update(scheduleDoc.ref, updateData);
         batchCount++;
         updatedCount++;
 
         console.log(`Scheduled update for schedule ${scheduleDoc.id}: ${currentVisibleToArray.length} -> ${newVisibleTo.length} members`);
 
-        // Firestoreのバッチ制限（500件）に達したら実行
-        if (batchCount >= 500) {
+        if (batchCount >= 450) {
           await batch.commit();
           console.log(`Committed batch of ${batchCount} updates`);
+          batch = db.batch();
           batchCount = 0;
         }
       }
     }
 
-    // 残りのバッチを実行
     if (batchCount > 0) {
       await batch.commit();
       console.log(`Committed final batch of ${batchCount} updates`);
@@ -95,6 +159,60 @@ export async function updateSchedulesVisibility(
     console.error(`Error updating schedules visibility for list ${listId}:`, error);
     throw error;
   }
+}
+
+async function calculateVisibleTo(
+  scheduleData: admin.firestore.DocumentData
+): Promise<string[]> {
+  const db = admin.firestore();
+  const ownerId = typeof scheduleData.ownerId === "string" ? scheduleData.ownerId : "";
+  const sharedLists = asStringArray(scheduleData.sharedLists);
+  const visibleTo = new Set<string>();
+
+  if (ownerId) {
+    visibleTo.add(ownerId);
+  }
+
+  for (const sharedListId of sharedLists) {
+    const listDoc = await db.collection("lists").doc(sharedListId).get();
+    if (!listDoc.exists) {
+      console.warn(`Shared list not found: ${sharedListId}`);
+      continue;
+    }
+
+    const listData = listDoc.data() || {};
+    for (const memberId of asStringArray(listData.memberIds)) {
+      visibleTo.add(memberId);
+    }
+  }
+
+  return Array.from(visibleTo);
+}
+
+function removeSharedListFromScheduleData(
+  scheduleData: admin.firestore.DocumentData,
+  listId?: string
+): admin.firestore.DocumentData {
+  if (!listId) {
+    return scheduleData;
+  }
+
+  return {
+    ...scheduleData,
+    sharedLists: asStringArray(scheduleData.sharedLists).filter(
+      (sharedListId) => sharedListId !== listId
+    ),
+  };
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => {
+    return typeof item === "string" && item.length > 0;
+  });
 }
 
 /**

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,7 @@ export * from "./handlers/group/triggers";
 
 // リスト関連のトリガーをエクスポート
 export * from "./handlers/list/triggers";
+export * from "./handlers/list/manual-sync";
 
 // 通知関連のトリガーをエクスポート
 export * from "./handlers/notification/triggers";

--- a/functions/src/test/list-visibility-recompute.test.ts
+++ b/functions/src/test/list-visibility-recompute.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+
+describe("List visibility recompute exports", () => {
+  it("should export backfill and delete helpers", async () => {
+    const {
+      backfillAllScheduleVisibility,
+      removeDeletedListFromSchedules,
+      updateSchedulesVisibility,
+    } = await import("../handlers/list/utils");
+
+    expect(backfillAllScheduleVisibility).to.be.a("function");
+    expect(removeDeletedListFromSchedules).to.be.a("function");
+    expect(updateSchedulesVisibility).to.be.a("function");
+  });
+
+  it("should export list deleted trigger and manual backfill function", async () => {
+    const { onListDeleted } = await import("../handlers/list/triggers");
+    const { backfillScheduleVisibility } = await import("../handlers/list/manual-sync");
+
+    expect(onListDeleted).to.not.be.undefined;
+    expect(backfillScheduleVisibility).to.not.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary
- `onListMemberUpdate` で対象リストの差分加減算ではなく、予定ごとに `sharedLists` の現在メンバーを読み直して `visibleTo` を再計算するようにしました。
- リスト削除時に対象予定から削除済みリストを外し、残りの共有リストから `visibleTo` を再計算する `onListDeleted` を追加しました。
- 既存予定の後方互換用に、`visibleTo` を一括再計算する `backfillScheduleVisibility` HTTP Function を追加しました。
- Functionsのimport/export確認テストを追加しました。

## Context
差分で `visibleTo` を足し引きすると、同じユーザーが複数リスト経由で共有されている予定から誤って閲覧権限を消す可能性があります。今回の実装では、変更対象リストを参照する予定ごとに `ownerId + sharedLists.memberIds` を正として再計算します。

## Validation
- `npm run lint`（既存の `functions/src/handlers/user/batch-sync.ts:56` の non-null assertion warning のみ）
- `npm run build`
- `npm run test:node20`（24 passing）
- dev FirebaseへFunctions deploy済み
- dev backfill実行済み: `{"scanned":3,"updated":0}`
- Flutter app側PRのGalaxy実機E2EでA/B/Cシナリオ成功済み

## Related
- App PR: https://github.com/keishimizu26629/LaKiite-flutter-app/pull/185