### PR TITLE
[codex] Tighten schedule interaction rules

### DIFF
--- a/security_rules/firestore/firestore.indexes.json
+++ b/security_rules/firestore/firestore.indexes.json
@@ -373,5 +373,26 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "reactions",
+      "fieldPath": "userId",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
+      "fieldPath": "userId",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    }
+  ]
 }

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -79,6 +79,12 @@ service cloud.firestore {
       );
     }
 
+    function hasOptionalStringOrNull(data, field) {
+      return !data.keys().hasAny([field])
+        || data[field] == null
+        || data[field] is string;
+    }
+
     // usersコレクションのルール
     match /users/{userId} {
       // 公開情報の読み取りと検索クエリを許可
@@ -262,12 +268,25 @@ service cloud.firestore {
       // reactionsサブコレクションのルール
       match /reactions/{reactionId} {
         // 読み取り: スケジュールにアクセス可能なユーザーのみ
-        allow read: if request.auth != null;
+        allow read: if request.auth != null
+          && canAccessSchedule(get(/databases/$(database)/documents/schedules/$(scheduleId)).data);
 
         // 作成・更新: スケジュールにアクセス可能なユーザーのみ、かつreactionIdは自分のユーザーIDと一致
         allow create, update: if request.auth != null
+          && canAccessSchedule(get(/databases/$(database)/documents/schedules/$(scheduleId)).data)
           && reactionId == request.auth.uid
-          && request.resource.data.userId == request.auth.uid;
+          && request.resource.data.keys().hasOnly([
+            'userId',
+            'type',
+            'createdAt',
+            'userDisplayName',
+            'userPhotoUrl'
+          ])
+          && request.resource.data.userId == request.auth.uid
+          && request.resource.data.type in ['going', 'thinking']
+          && request.resource.data.createdAt is timestamp
+          && request.resource.data.userDisplayName is string
+          && hasOptionalStringOrNull(request.resource.data, 'userPhotoUrl');
 
         // 削除: 自分のリアクションのみ
         allow delete: if request.auth != null && reactionId == request.auth.uid;
@@ -280,12 +299,26 @@ service cloud.firestore {
 
         // 作成: 認証済みユーザーであれば作成可能
         allow create: if request.auth != null
+          && canAccessSchedule(get(/databases/$(database)/documents/schedules/$(scheduleId)).data)
+          && request.resource.data.keys().hasOnly([
+            'userId',
+            'content',
+            'createdAt',
+            'updatedAt',
+            'isEdited',
+            'userDisplayName',
+            'userPhotoUrl'
+          ])
           // userId は自分自身でなければならない
           && request.resource.data.userId == request.auth.uid
           // 必須フィールドの型チェック
           && request.resource.data.content is string
           && request.resource.data.createdAt is timestamp
-          && request.resource.data.updatedAt is timestamp;
+          && request.resource.data.updatedAt is timestamp
+          && request.resource.data.isEdited is bool
+          && request.resource.data.isEdited == false
+          && request.resource.data.userDisplayName is string
+          && hasOptionalStringOrNull(request.resource.data, 'userPhotoUrl');
 
         // 更新: 自分のコメントのみ
         allow update: if request.auth != null

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -221,6 +221,7 @@ describe('Schedules Collection Security Rules', () => {
           title: 'Test Schedule',
           ownerId: 'user1',
           visibleTo: ['user2'],
+          sharedLists: [],
           reactionCount: 0,
           commentCount: 0
         }
@@ -235,8 +236,39 @@ describe('Schedules Collection Security Rules', () => {
       await expectSuccess(
         db.doc('schedules/schedule1/reactions/user2').set({
           userId: 'user2',
+          type: 'going',
+          createdAt: new Date(),
+          userDisplayName: 'Test User 2',
+          userPhotoUrl: null
+        })
+      );
+    });
+
+    test('不正なリアクション種別では作成できない', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          title: 'Test Schedule',
+          ownerId: 'user1',
+          visibleTo: ['user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectFailure(
+        db.doc('schedules/schedule1/reactions/user2').set({
+          userId: 'user2',
           type: 'like',
-          createdAt: new Date()
+          createdAt: new Date(),
+          userDisplayName: 'Test User 2',
+          userPhotoUrl: null
         })
       );
     });
@@ -247,6 +279,7 @@ describe('Schedules Collection Security Rules', () => {
           title: 'Test Schedule',
           ownerId: 'user1',
           visibleTo: ['user2'],
+          sharedLists: [],
           reactionCount: 0,
           commentCount: 0
         }
@@ -261,8 +294,39 @@ describe('Schedules Collection Security Rules', () => {
       await expectFailure(
         db.doc('schedules/schedule1/reactions/user3').set({
           userId: 'user3', // 他人のID
-          type: 'like',
-          createdAt: new Date()
+          type: 'going',
+          createdAt: new Date(),
+          userDisplayName: 'Test User 3',
+          userPhotoUrl: null
+        })
+      );
+    });
+
+    test('予定にアクセスできないユーザーはリアクションを作成できない', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          title: 'Test Schedule',
+          ownerId: 'user1',
+          visibleTo: ['user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user3' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectFailure(
+        db.doc('schedules/schedule1/reactions/user3').set({
+          userId: 'user3',
+          type: 'thinking',
+          createdAt: new Date(),
+          userDisplayName: 'Test User 3',
+          userPhotoUrl: null
         })
       );
     });
@@ -275,6 +339,7 @@ describe('Schedules Collection Security Rules', () => {
           title: 'Test Schedule',
           ownerId: 'user1',
           visibleTo: ['user2'],
+          sharedLists: [],
           reactionCount: 0,
           commentCount: 0
         }
@@ -291,7 +356,10 @@ describe('Schedules Collection Security Rules', () => {
           userId: 'user2',
           content: 'Great schedule!',
           createdAt: new Date(),
-          updatedAt: new Date()
+          updatedAt: new Date(),
+          isEdited: false,
+          userDisplayName: 'Test User 2',
+          userPhotoUrl: null
         })
       );
     });
@@ -302,6 +370,7 @@ describe('Schedules Collection Security Rules', () => {
           title: 'Test Schedule',
           ownerId: 'user1',
           visibleTo: ['user2'],
+          sharedLists: [],
           reactionCount: 0,
           commentCount: 0
         },
@@ -335,6 +404,7 @@ describe('Schedules Collection Security Rules', () => {
           title: 'Test Schedule',
           ownerId: 'user1',
           visibleTo: ['user2', 'user3'],
+          sharedLists: [],
           reactionCount: 0,
           commentCount: 0
         },


### PR DESCRIPTION
## Summary
- Align schedule reaction/comment rules with the client-written snapshot fields
- Restrict interaction reads and writes to users who can access the parent schedule
- Add collection group userId field indexes for profile synchronization queries

## Why
Reactions and comments store snapshot user metadata, including userPhotoUrl. The rules needed to allow that structure while validating it, and profile synchronization requires collection group indexes on userId.

## Validation
- npm --prefix functions run build
- git diff --check
- npm run deploy:rules:dev
- npm --prefix functions run deploy:functions:dev
- npm run deploy:indexes:dev
- Galaxy RFCW31S5JLJ dev app + Firestore REST: recreated B account reaction/comment and confirmed userPhotoUrl=https://placehold.co/128x128/0f766e/ffffff.png?text=B2

## Note
Rules emulator tests were intentionally not run per request.
