### PR TITLE
fix: add calendar overlap Firestore index

### DIFF
--- a/security_rules/firestore/firestore.indexes.json
+++ b/security_rules/firestore/firestore.indexes.json
@@ -52,6 +52,24 @@
         },
         {
           "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endDateTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "schedules",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "visibleTo",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "startDateTime",
           "order": "DESCENDING"
         }
       ]


### PR DESCRIPTION
## Summary
- add schedules composite index for `visibleTo` + `startDateTime` + `endDateTime`
- supports the monthly calendar overlap query from the Flutter app

## Deployment
- Deployed indexes to `lakiite-flutter-app-dev`
- Confirmed the `visibleTo` / `startDateTime` / `endDateTime` index is `READY`

## Test Plan
- JSON validation confirmed `{"indexes":23,"hasCalendarOverlapIndex":true}`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" npm run emulator:test:ci`