### PR TITLE
feat: add app version settings rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "deploy:rules:prod": "npm --prefix functions run deploy:rules:prod",
     "deploy:indexes:dev": "npm --prefix functions run deploy:indexes:dev",
     "deploy:indexes:prod": "npm --prefix functions run deploy:indexes:prod",
+    "set:app-version:dev": "node scripts/set-app-version.js dev",
+    "set:app-version:prod": "node scripts/set-app-version.js prod",
     "logs:functions:dev": "npm --prefix functions run logs:dev",
     "logs:functions:prod": "npm --prefix functions run logs:prod"
   },

--- a/scripts/set-app-version.js
+++ b/scripts/set-app-version.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function requireFirebaseAdmin() {
+  try {
+    return require('../functions/node_modules/firebase-admin');
+  } catch (error) {
+    throw new Error(
+      'firebase-admin が見つかりません。先に `npm --prefix functions ci` を実行してください。'
+    );
+  }
+}
+
+function usage() {
+  console.log(`Usage:
+  node scripts/set-app-version.js <dev|prod> [--apply]
+
+Environment overrides:
+  APP_VERSION
+  IOS_LATEST_VERSION
+  ANDROID_LATEST_VERSION
+  IOS_MIN_REQUIRED_VERSION
+  ANDROID_MIN_REQUIRED_VERSION
+  APP_STORE_URL
+  GOOGLE_PLAY_URL
+  FORCE_UPDATE
+  APP_UPDATE_TITLE
+  APP_UPDATE_CONTENT
+
+Examples:
+  node scripts/set-app-version.js dev
+  node scripts/set-app-version.js dev --apply
+  APP_VERSION=1.0.1 node scripts/set-app-version.js prod --apply
+`);
+}
+
+function readProjectId(alias) {
+  const firebaseRcPath = path.join(__dirname, '..', '.firebaserc');
+  const firebaseRc = JSON.parse(fs.readFileSync(firebaseRcPath, 'utf8'));
+  return firebaseRc.projects?.[alias] ?? alias;
+}
+
+function envBool(name, defaultValue) {
+  const value = process.env[name];
+  if (value == null || value === '') {
+    return defaultValue;
+  }
+  return value === 'true';
+}
+
+function buildSettings() {
+  const appVersion = process.env.APP_VERSION || '1.0.0';
+
+  return {
+    forceUpdate: envBool('FORCE_UPDATE', false),
+    iOSLatestVersion: process.env.IOS_LATEST_VERSION || appVersion,
+    androidLatestVersion: process.env.ANDROID_LATEST_VERSION || appVersion,
+    iOSMinRequiredVersion:
+      process.env.IOS_MIN_REQUIRED_VERSION || appVersion,
+    androidMinRequiredVersion:
+      process.env.ANDROID_MIN_REQUIRED_VERSION || appVersion,
+    appStoreUrl: process.env.APP_STORE_URL || '',
+    googlePlayUrl: process.env.GOOGLE_PLAY_URL || '',
+    title: process.env.APP_UPDATE_TITLE || 'アプリの更新',
+    content:
+      process.env.APP_UPDATE_CONTENT ||
+      '最新バージョンへ更新してください。',
+  };
+}
+
+async function main() {
+  const target = process.argv[2];
+  const shouldApply = process.argv.includes('--apply');
+
+  if (!target || target === '--help' || target === '-h') {
+    usage();
+    process.exit(target ? 0 : 1);
+  }
+
+  const projectId = readProjectId(target);
+  const settings = buildSettings();
+
+  console.log(`Project: ${projectId}`);
+  console.log('Document: settings/appVersion');
+  console.log(JSON.stringify(settings, null, 2));
+
+  if (!shouldApply) {
+    console.log('dry-run: Firestore には書き込んでいません。実行するには --apply を付けてください。');
+    return;
+  }
+
+  const admin = requireFirebaseAdmin();
+  admin.initializeApp({projectId});
+  await admin.firestore().doc('settings/appVersion').set(settings, {merge: true});
+  console.log('settings/appVersion を更新しました。');
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -86,6 +86,45 @@ service cloud.firestore {
         || data[field] is string;
     }
 
+    function hasRequiredAppVersionFields(data) {
+      return data.keys().hasAll([
+          'forceUpdate',
+          'iOSLatestVersion',
+          'androidLatestVersion',
+          'iOSMinRequiredVersion',
+          'androidMinRequiredVersion',
+          'appStoreUrl',
+          'googlePlayUrl',
+          'title',
+          'content'
+        ])
+        && data.forceUpdate is bool
+        && data.iOSLatestVersion is string
+        && data.androidLatestVersion is string
+        && data.iOSMinRequiredVersion is string
+        && data.androidMinRequiredVersion is string
+        && data.appStoreUrl is string
+        && data.googlePlayUrl is string
+        && data.title is string
+        && data.content is string;
+    }
+
+    // settingsコレクションのルール
+    match /settings/{settingId} {
+      // 強制アップデート判定はログイン前にも必要なため公開読み取りを許可する。
+      allow read: if settingId == 'appVersion';
+
+      // 更新設定は管理者のみ書き込み可能。
+      allow create, update: if request.auth != null
+        && isAdmin()
+        && settingId == 'appVersion'
+        && hasRequiredAppVersionFields(request.resource.data);
+
+      allow delete: if request.auth != null
+        && isAdmin()
+        && settingId == 'appVersion';
+    }
+
     // usersコレクションのルール
     match /users/{userId} {
       // 公開情報の読み取りと検索クエリを許可

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,93 @@
+const {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  expectSuccess,
+  expectFailure
+} = require('./helpers');
+
+describe('Settings Collection Security Rules', () => {
+  afterEach(async () => {
+    try {
+      await teardownTestEnvironment();
+    } catch (error) {
+      console.warn('Teardown warning:', error.message);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      await teardownTestEnvironment();
+    } catch (error) {
+      console.warn('Final teardown warning:', error.message);
+    }
+  });
+
+  describe('appVersion', () => {
+    test('未認証ユーザーはappVersionを読み取れる', async () => {
+      const context = await setupTestEnvironment(null, {
+        'settings/appVersion': appVersionSettings()
+      });
+      const db = context.firestore();
+
+      await expectSuccess(db.doc('settings/appVersion').get());
+    });
+
+    test('未認証ユーザーはappVersion以外のsettingsを読み取れない', async () => {
+      const context = await setupTestEnvironment(null, {
+        'settings/privateConfig': { value: 'secret' }
+      });
+      const db = context.firestore();
+
+      await expectFailure(db.doc('settings/privateConfig').get());
+    });
+
+    test('一般ユーザーはappVersionを書き込めない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('settings/appVersion').set(appVersionSettings())
+      );
+    });
+
+    test('管理者はappVersionを書き込める', async () => {
+      const context = await setupTestEnvironment({
+        uid: 'admin1',
+        admin: true
+      });
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('settings/appVersion').set(appVersionSettings())
+      );
+    });
+
+    test('管理者でも必須フィールドが不足しているappVersionは書き込めない', async () => {
+      const context = await setupTestEnvironment({
+        uid: 'admin1',
+        admin: true
+      });
+      const db = context.firestore();
+      const invalidSettings = appVersionSettings();
+      delete invalidSettings.androidMinRequiredVersion;
+
+      await expectFailure(
+        db.doc('settings/appVersion').set(invalidSettings)
+      );
+    });
+  });
+});
+
+function appVersionSettings() {
+  return {
+    forceUpdate: false,
+    iOSLatestVersion: '1.0.0',
+    androidLatestVersion: '1.0.0',
+    iOSMinRequiredVersion: '1.0.0',
+    androidMinRequiredVersion: '1.0.0',
+    appStoreUrl: '',
+    googlePlayUrl: '',
+    title: 'アプリの更新',
+    content: '最新バージョンへ更新してください。'
+  };
+}


### PR DESCRIPTION
## Summary
- Add Firestore rules for settings/appVersion
- Allow public reads for appVersion and restrict writes/deletes to admins
- Add a dry-run-first script for setting the initial appVersion document
- Add rules tests for public read, non-admin write denial, admin write success, and required fields

## Test Plan
- npm run set:app-version:dev
- npm run set:app-version:prod
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:exec --only firestore --project demo-test "npm test -- --runInBand tests/settings.test.js"

## Notes
- The app version script defaults to dry-run. Firestore is only updated when --apply is passed.