### PR TITLE
[codex] Add display list Firestore rules

### DIFF
--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -89,8 +89,6 @@ service cloud.firestore {
     function isValidDisplayListColorKey(colorKey) {
       return [
         'red',
-        'orange',
-        'amber',
         'green',
         'teal',
         'cyan',

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -86,6 +86,39 @@ service cloud.firestore {
         || data[field] is string;
     }
 
+    function isValidDisplayListColorKey(colorKey) {
+      return [
+        'red',
+        'orange',
+        'amber',
+        'green',
+        'teal',
+        'cyan',
+        'blue',
+        'indigo',
+        'purple',
+        'pink'
+      ].hasAny([colorKey]);
+    }
+
+    function hasRequiredDisplayListFields(data) {
+      return data.keys().hasOnly([
+          'name',
+          'ownerId',
+          'colorKey',
+          'memberIds',
+          'createdAt',
+          'updatedAt'
+        ])
+        && data.name is string
+        && data.ownerId is string
+        && data.colorKey is string
+        && isValidDisplayListColorKey(data.colorKey)
+        && data.memberIds is list
+        && data.createdAt != null
+        && data.updatedAt != null;
+    }
+
     // usersコレクションのルール
     match /users/{userId} {
       // 公開情報の読み取りと検索クエリを許可
@@ -126,6 +159,20 @@ service cloud.firestore {
         allow create, update: if request.auth != null
           && request.auth.uid == userId
           && hasRequiredPrivateFields(request.resource.data);
+      }
+
+      // Display Lists Subcollection Rules
+      match /displayLists/{displayListId} {
+        allow read, list: if request.auth != null
+          && request.auth.uid == userId;
+
+        allow create, update: if request.auth != null
+          && request.auth.uid == userId
+          && request.resource.data.ownerId == userId
+          && hasRequiredDisplayListFields(request.resource.data);
+
+        allow delete: if request.auth != null
+          && request.auth.uid == userId;
       }
     }
 

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -185,4 +185,67 @@ describe('Users Collection Security Rules', () => {
       await expectFailure(db.doc('users/user1/private/profile').get());
     });
   });
+
+  describe('表示用リストサブコレクション', () => {
+    const displayListData = {
+      name: '家族',
+      ownerId: 'user1',
+      colorKey: 'teal',
+      memberIds: ['user2'],
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    test('ユーザーは自分の表示用リストを読み取れる', async () => {
+      const mockData = {
+        'users/user1/displayLists/list1': displayListData
+      };
+
+      const context = await setupTestEnvironment({ uid: 'user1' }, mockData);
+      const db = context.firestore();
+
+      await expectSuccess(db.doc('users/user1/displayLists/list1').get());
+    });
+
+    test('ユーザーは他人の表示用リストを読み取れない', async () => {
+      const mockData = {
+        'users/user1/displayLists/list1': displayListData
+      };
+
+      const context = await setupTestEnvironment({ uid: 'user2' }, mockData);
+      const db = context.firestore();
+
+      await expectFailure(db.doc('users/user1/displayLists/list1').get());
+    });
+
+    test('ユーザーは自分の表示用リストを作成できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('users/user1/displayLists/list1').set(displayListData)
+      );
+    });
+
+    test('ユーザーは他人の表示用リストを作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user2' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('users/user1/displayLists/list1').set(displayListData)
+      );
+    });
+
+    test('無効なカラーキーの表示用リストは作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('users/user1/displayLists/list1').set({
+          ...displayListData,
+          colorKey: 'unknown'
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Allow users to manage their own users/{uid}/displayLists subcollection
- Validate display-list required fields and fixed color keys
- Add Firestore rules tests for own/other user access and invalid colors

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home firebase emulators:exec --only firestore,storage "sleep 3 && npm test" --project lakiite-flutter-app-dev
- Deployed firestore rules to lakiite-flutter-app-dev