### PR TITLE
feat: add morning schedule digest functions

### DIFF
--- a/functions/src/handlers/schedule-digest/manual-sync.ts
+++ b/functions/src/handlers/schedule-digest/manual-sync.ts
@@ -1,0 +1,48 @@
+import * as functions from "firebase-functions/v2/https";
+import * as admin from "firebase-admin";
+import { backfillAllScheduleDigestSettings } from "./utils";
+
+export const backfillScheduleDigestSettings = functions.onRequest(
+  {
+    region: "asia-northeast1",
+    cors: true,
+  },
+  async (req, res) => {
+    try {
+      res.set("Access-Control-Allow-Origin", "*");
+      res.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+      res.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+      if (req.method === "OPTIONS") {
+        res.status(204).send("");
+        return;
+      }
+
+      if (req.method !== "POST") {
+        res.status(405).send({error: "Method Not Allowed"});
+        return;
+      }
+
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        res.status(401).send({error: "認証が必要です"});
+        return;
+      }
+
+      const token = authHeader.split("Bearer ")[1];
+      const decodedToken = await admin.auth().verifyIdToken(token);
+      if (decodedToken.admin !== true) {
+        res.status(403).send({error: "管理者権限が必要です"});
+        return;
+      }
+
+      const result = await backfillAllScheduleDigestSettings();
+      res.status(200).send({success: true, result});
+    } catch (error) {
+      console.error("Schedule digest settings backfill failed:", error);
+      res.status(500).send({
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+);

--- a/functions/src/handlers/schedule-digest/triggers.ts
+++ b/functions/src/handlers/schedule-digest/triggers.ts
@@ -1,0 +1,173 @@
+import * as functions from "firebase-functions/v2/scheduler";
+import * as admin from "firebase-admin";
+import {
+  createDefaultScheduleDigestSettingsIfMissing,
+  getJstHour,
+  getTodayScheduleRangeIso,
+  isMorningNotifyHour,
+  shouldSendScheduleDigest,
+} from "./utils";
+
+interface DigestTarget {
+  userId: string;
+  tokens: string[];
+  count: number;
+}
+
+export const sendMorningScheduleDigest = functions.onSchedule(
+  {
+    schedule: "0 0-9 * * *",
+    timeZone: "Asia/Tokyo",
+    region: "asia-northeast1",
+    memory: "1GiB",
+    timeoutSeconds: 540,
+  },
+  async () => {
+    const notifyHour = getJstHour();
+    if (!isMorningNotifyHour(notifyHour)) {
+      console.log(`朝通知対象外の時刻です: notifyHour=${notifyHour}`);
+      return;
+    }
+
+    const range = getTodayScheduleRangeIso();
+    const settingsSnapshot = await admin
+      .firestore()
+      .collection("scheduleDigestSettings")
+      .where("enabled", "==", true)
+      .where("notifyHour", "==", notifyHour)
+      .get();
+
+    if (settingsSnapshot.empty) {
+      console.log(`朝通知対象ユーザーなし: notifyHour=${notifyHour}`);
+      return;
+    }
+
+    const targets: DigestTarget[] = [];
+    let skippedAlreadySent = 0;
+    let skippedNoSchedules = 0;
+
+    for (const settingsDoc of settingsSnapshot.docs) {
+      const settings = settingsDoc.data();
+      const userId = settingsDoc.id;
+
+      if (settings.lastSentDate === range.today) {
+        skippedAlreadySent++;
+        continue;
+      }
+
+      const count = await countVisibleSchedulesForToday(userId, range);
+      if (!shouldSendScheduleDigest(count)) {
+        skippedNoSchedules++;
+        await markDigestProcessed(settingsDoc.ref, range.today);
+        continue;
+      }
+
+      const tokens = await getUserFcmTokens(userId);
+      if (tokens.length === 0) {
+        await markDigestProcessed(settingsDoc.ref, range.today);
+        continue;
+      }
+
+      targets.push({userId, tokens, count});
+    }
+
+    for (const target of targets) {
+      await sendDigestToTarget(target, range.today);
+      await markDigestProcessed(
+        admin.firestore().collection("scheduleDigestSettings").doc(target.userId),
+        range.today
+      );
+    }
+
+    console.log(
+      `朝通知完了: notifyHour=${notifyHour}, sent=${targets.length}, ` +
+        `alreadySent=${skippedAlreadySent}, noSchedules=${skippedNoSchedules}`
+    );
+  }
+);
+
+export async function onScheduleDigestUserCreated(userId: string): Promise<void> {
+  await createDefaultScheduleDigestSettingsIfMissing(userId);
+}
+
+async function countVisibleSchedulesForToday(
+  userId: string,
+  range: { startInclusiveIso: string; endExclusiveIso: string }
+): Promise<number> {
+  const snapshot = await admin
+    .firestore()
+    .collection("schedules")
+    .where("visibleTo", "array-contains", userId)
+    .where("startDateTime", "<", range.endExclusiveIso)
+    .where("endDateTime", ">=", range.startInclusiveIso)
+    .count()
+    .get();
+
+  return snapshot.data().count;
+}
+
+async function getUserFcmTokens(userId: string): Promise<string[]> {
+  const userDoc = await admin.firestore().collection("users").doc(userId).get();
+  const rawTokens = userDoc.data()?.fcmTokens;
+  if (!Array.isArray(rawTokens)) {
+    return [];
+  }
+
+  return [...new Set(rawTokens.filter((token): token is string => {
+    return typeof token === "string" && token.length > 0;
+  }))];
+}
+
+async function sendDigestToTarget(target: DigestTarget, today: string): Promise<void> {
+  const messages = target.tokens.map((token) => ({
+    token,
+    notification: {
+      title: "今日の共有予定",
+      body: `今日あなたに共有されている予定が${target.count}件あります`,
+    },
+    data: {
+      type: "schedule_digest",
+      date: today,
+      scheduleCount: String(target.count),
+      timestamp: Date.now().toString(),
+    },
+    android: {
+      notification: {
+        icon: "notification_icon",
+        color: "#ffa600",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: {
+          badge: 1,
+          sound: "default",
+        },
+      },
+    },
+  }));
+
+  const response = await admin.messaging().sendEach(messages);
+  response.responses.forEach((sendResponse, index) => {
+    if (!sendResponse.success) {
+      console.error(
+        `朝通知送信失敗: userId=${target.userId}, tokenIndex=${index}`,
+        sendResponse.error
+      );
+    }
+  });
+}
+
+async function markDigestProcessed(
+  ref: admin.firestore.DocumentReference,
+  today: string
+): Promise<void> {
+  await ref.set(
+    {
+      lastSentDate: today,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    {merge: true}
+  );
+}

--- a/functions/src/handlers/schedule-digest/utils.ts
+++ b/functions/src/handlers/schedule-digest/utils.ts
@@ -1,0 +1,137 @@
+import * as admin from "firebase-admin";
+
+export interface ScheduleDigestSettingsData {
+  enabled: boolean;
+  notifyHour: number;
+  lastSentDate: string | null;
+  createdAt: admin.firestore.FieldValue;
+  updatedAt: admin.firestore.FieldValue;
+}
+
+export function buildDefaultScheduleDigestSettings(): ScheduleDigestSettingsData {
+  return {
+    enabled: true,
+    notifyHour: 8,
+    lastSentDate: null,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+}
+
+export function isMorningNotifyHour(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 9;
+}
+
+export function shouldSendScheduleDigest(sharedScheduleCount: number): boolean {
+  return sharedScheduleCount > 0;
+}
+
+export async function createDefaultScheduleDigestSettingsIfMissing(
+  userId: string
+): Promise<boolean> {
+  const ref = admin.firestore().collection("scheduleDigestSettings").doc(userId);
+  const snapshot = await ref.get();
+  if (snapshot.exists) {
+    return false;
+  }
+
+  await ref.set(buildDefaultScheduleDigestSettings());
+  return true;
+}
+
+export async function backfillAllScheduleDigestSettings(): Promise<{
+  scanned: number;
+  created: number;
+  skipped: number;
+}> {
+  const db = admin.firestore();
+  const usersSnapshot = await db.collection("users").get();
+  let batch = db.batch();
+  let batchCount = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const userDoc of usersSnapshot.docs) {
+    const settingsRef = db.collection("scheduleDigestSettings").doc(userDoc.id);
+    const settingsSnapshot = await settingsRef.get();
+    if (settingsSnapshot.exists) {
+      skipped++;
+      continue;
+    }
+
+    batch.set(settingsRef, buildDefaultScheduleDigestSettings());
+    batchCount++;
+    created++;
+
+    if (batchCount >= 450) {
+      await batch.commit();
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  if (batchCount > 0) {
+    await batch.commit();
+  }
+
+  return {
+    scanned: usersSnapshot.size,
+    created,
+    skipped,
+  };
+}
+
+export function getJstDateString(date = new Date()): string {
+  const parts = getJstDateParts(date);
+  return formatDateParts(parts);
+}
+
+export function getJstHour(date = new Date()): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Tokyo",
+    hour: "2-digit",
+    hour12: false,
+  });
+  return Number(formatter.format(date));
+}
+
+export function getTodayScheduleRangeIso(date = new Date()): {
+  today: string;
+  startInclusiveIso: string;
+  endExclusiveIso: string;
+} {
+  const parts = getJstDateParts(date);
+  const tomorrow = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + 1));
+  const tomorrowParts = getJstDateParts(tomorrow);
+  const today = formatDateParts(parts);
+  const nextDay = formatDateParts(tomorrowParts);
+
+  return {
+    today,
+    startInclusiveIso: `${today}T00:00:00.000`,
+    endExclusiveIso: `${nextDay}T00:00:00.000`,
+  };
+}
+
+function getJstDateParts(date: Date): { year: number; month: number; day: number } {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(date);
+  return {
+    year: Number(parts.find((part) => part.type === "year")?.value),
+    month: Number(parts.find((part) => part.type === "month")?.value),
+    day: Number(parts.find((part) => part.type === "day")?.value),
+  };
+}
+
+function formatDateParts(parts: { year: number; month: number; day: number }): string {
+  return [
+    String(parts.year).padStart(4, "0"),
+    String(parts.month).padStart(2, "0"),
+    String(parts.day).padStart(2, "0"),
+  ].join("-");
+}

--- a/functions/src/handlers/user/triggers.ts
+++ b/functions/src/handlers/user/triggers.ts
@@ -3,6 +3,22 @@ import * as admin from "firebase-admin";
 import { cleanupRetiredUserReferences } from "./deletion-cleanup";
 import { processUserUpdates } from "./batch-sync";
 import { buildUserProfileUpdates } from "./profile-sync";
+import { onScheduleDigestUserCreated } from "../schedule-digest/triggers";
+
+export const onUserCreated = functions.onDocumentCreated(
+  {
+    document: "users/{userId}",
+    region: "asia-northeast1",
+  },
+  async (event) => {
+    try {
+      await onScheduleDigestUserCreated(event.params.userId);
+      console.log(`朝通知設定の初期作成完了: ${event.params.userId}`);
+    } catch (error) {
+      console.error("朝通知設定の初期作成エラー:", error);
+    }
+  }
+);
 
 /**
  * ユーザー情報更新時に履歴を記録

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,8 @@ export * from "./handlers/notification/triggers";
 
 // スケジュール関連のトリガーをエクスポート
 export * from "./handlers/schedule/triggers";
+export * from "./handlers/schedule-digest/triggers";
+export * from "./handlers/schedule-digest/manual-sync";
 
 // ユーザー関連のトリガーをエクスポート
 export * from "./handlers/user/triggers";

--- a/functions/src/test/schedule-digest.test.ts
+++ b/functions/src/test/schedule-digest.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+
+describe("Schedule digest helpers", () => {
+  it("builds default settings enabled at 8", async () => {
+    const { buildDefaultScheduleDigestSettings } = await import("../handlers/schedule-digest/utils");
+
+    const settings = buildDefaultScheduleDigestSettings();
+
+    expect(settings.enabled).to.equal(true);
+    expect(settings.notifyHour).to.equal(8);
+    expect(settings.lastSentDate).to.equal(null);
+  });
+
+  it("only accepts 0-9 as morning notifyHour", async () => {
+    const { isMorningNotifyHour } = await import("../handlers/schedule-digest/utils");
+
+    expect(isMorningNotifyHour(0)).to.equal(true);
+    expect(isMorningNotifyHour(9)).to.equal(true);
+    expect(isMorningNotifyHour(10)).to.equal(false);
+    expect(isMorningNotifyHour(-1)).to.equal(false);
+  });
+
+  it("does not send when shared schedule count is zero", async () => {
+    const { shouldSendScheduleDigest } = await import("../handlers/schedule-digest/utils");
+
+    expect(shouldSendScheduleDigest(0)).to.equal(false);
+    expect(shouldSendScheduleDigest(1)).to.equal(true);
+  });
+});

--- a/functions/src/test/user-triggers.test.ts
+++ b/functions/src/test/user-triggers.test.ts
@@ -1,6 +1,15 @@
 import { expect } from "chai";
 
 describe("User Triggers", () => {
+  describe("onUserCreated", () => {
+    it("should be importable", async () => {
+      const { onUserCreated } = await import("../handlers/user/triggers");
+
+      expect(onUserCreated).to.not.be.undefined;
+      expect(typeof onUserCreated).to.equal("function");
+    });
+  });
+
   describe("onUserUpdate", () => {
     it("should be importable", async () => {
       // トリガー関数がインポートできることを確認

--- a/security_rules/firestore/firestore.indexes.json
+++ b/security_rules/firestore/firestore.indexes.json
@@ -1,6 +1,20 @@
 {
   "indexes": [
     {
+      "collectionGroup": "scheduleDigestSettings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "enabled",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "notifyHour",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "lists",
       "queryScope": "COLLECTION",
       "fields": [

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -140,6 +140,25 @@ service cloud.firestore {
         && data.content is string;
     }
 
+    function hasValidScheduleDigestSettingsFields(data) {
+      return data.keys().hasOnly([
+          'enabled',
+          'notifyHour',
+          'lastSentDate',
+          'createdAt',
+          'updatedAt'
+        ])
+        && data.enabled is bool
+        && data.notifyHour is number
+        && data.notifyHour >= 0
+        && data.notifyHour <= 9
+        && (!data.keys().hasAny(['lastSentDate'])
+          || data.lastSentDate == null
+          || data.lastSentDate is string)
+        && (!data.keys().hasAny(['createdAt']) || data.createdAt != null)
+        && data.updatedAt != null;
+    }
+
     // settingsコレクションのルール
     match /settings/{settingId} {
       // 強制アップデート判定はログイン前にも必要なため公開読み取りを許可する。
@@ -154,6 +173,18 @@ service cloud.firestore {
       allow delete: if request.auth != null
         && isAdmin()
         && settingId == 'appVersion';
+    }
+
+    match /scheduleDigestSettings/{userId} {
+      allow read: if request.auth != null
+        && request.auth.uid == userId;
+
+      allow create, update: if request.auth != null
+        && request.auth.uid == userId
+        && hasValidScheduleDigestSettingsFields(request.resource.data);
+
+      allow delete: if request.auth != null
+        && request.auth.uid == userId;
     }
 
     // usersコレクションのルール

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -76,6 +76,46 @@ describe('Settings Collection Security Rules', () => {
       );
     });
   });
+
+  describe('scheduleDigestSettings', () => {
+    test('ユーザーは自分の朝通知設定を読み取れる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' }, {
+        'scheduleDigestSettings/user1': scheduleDigestSettings()
+      });
+      const db = context.firestore();
+
+      await expectSuccess(db.doc('scheduleDigestSettings/user1').get());
+    });
+
+    test('ユーザーは他人の朝通知設定を読み取れない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user2' }, {
+        'scheduleDigestSettings/user1': scheduleDigestSettings()
+      });
+      const db = context.firestore();
+
+      await expectFailure(db.doc('scheduleDigestSettings/user1').get());
+    });
+
+    test('ユーザーは自分の朝通知設定を作成できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('scheduleDigestSettings/user1').set(scheduleDigestSettings())
+      );
+    });
+
+    test('10時以降の朝通知設定は作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+      const data = scheduleDigestSettings();
+      data.notifyHour = 10;
+
+      await expectFailure(
+        db.doc('scheduleDigestSettings/user1').set(data)
+      );
+    });
+  });
 });
 
 function appVersionSettings() {
@@ -89,5 +129,14 @@ function appVersionSettings() {
     googlePlayUrl: '',
     title: 'アプリの更新',
     content: '最新バージョンへ更新してください。'
+  };
+}
+
+function scheduleDigestSettings() {
+  return {
+    enabled: true,
+    notifyHour: 8,
+    lastSentDate: null,
+    updatedAt: new Date()
   };
 }


### PR DESCRIPTION
## Summary
- Add schedule digest defaults, backfill, user-create setup, scheduler, and admin manual sync endpoint.
- Send morning schedule digest notifications only for enabled users in the selected 0-9 JST hour.
- Skip sending when the user has no shared schedules at send time, and update `lastSentDate` to avoid repeated checks that day.
- Add Firestore rules and index for `scheduleDigestSettings`.

## Test Plan
- `npm run build` with Node 20.9.0
- `./node_modules/.bin/eslint --ext .ts ...`
- `npm test` with Node 20.9.0
- `git diff --check`

## Related Issues
- Supports keishimizu26629/LaKiite-flutter-app#225
- Follow-up: keishimizu26629/LaKiite-flutter-app#233