### PR TITLE
feat: auto accept example friends and sync removals

### DIFF
--- a/functions/src/handlers/user/friend-sync.ts
+++ b/functions/src/handlers/user/friend-sync.ts
@@ -1,0 +1,159 @@
+import * as admin from "firebase-admin";
+
+interface PrivateProfileSnapshot {
+  friends?: unknown;
+}
+
+type FriendRemovalCleanupTarget =
+  | {
+      kind: "friendPrivateProfile";
+      userId: string;
+      friendId: string;
+    }
+  | {
+      kind: "ownedLists" | "displayLists" | "ownedSchedules";
+      ownerId: string;
+      memberId: string;
+    };
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export function getRemovedFriendIds(
+  before: PrivateProfileSnapshot,
+  after: PrivateProfileSnapshot
+): string[] {
+  const beforeFriendIds = asStringArray(before.friends);
+  const afterFriendIds = new Set(asStringArray(after.friends));
+
+  return beforeFriendIds.filter((friendId) => !afterFriendIds.has(friendId));
+}
+
+export async function mirrorRemovedFriendReferences(
+  userId: string,
+  removedFriendIds: string[]
+) {
+  for (const friendId of removedFriendIds) {
+    await applyFriendRemovalCleanupTargets(
+      buildFriendRemovalCleanupTargets(userId, friendId)
+    );
+  }
+}
+
+export function buildFriendRemovalCleanupTargets(
+  userId: string,
+  friendId: string
+): FriendRemovalCleanupTarget[] {
+  return [
+    { kind: "friendPrivateProfile", userId, friendId },
+    { kind: "ownedLists", ownerId: userId, memberId: friendId },
+    { kind: "ownedLists", ownerId: friendId, memberId: userId },
+    { kind: "displayLists", ownerId: userId, memberId: friendId },
+    { kind: "displayLists", ownerId: friendId, memberId: userId },
+    { kind: "ownedSchedules", ownerId: userId, memberId: friendId },
+    { kind: "ownedSchedules", ownerId: friendId, memberId: userId },
+  ];
+}
+
+async function applyFriendRemovalCleanupTargets(
+  targets: FriendRemovalCleanupTarget[]
+) {
+  await Promise.all(
+    targets.map((target) => {
+      switch (target.kind) {
+      case "friendPrivateProfile":
+        return removeFromFriendPrivateProfile(target.userId, target.friendId);
+      case "ownedLists":
+        return removeMemberFromOwnedLists(target.ownerId, target.memberId);
+      case "displayLists":
+        return removeMemberFromDisplayLists(target.ownerId, target.memberId);
+      case "ownedSchedules":
+        return removeMemberFromOwnedSchedules(target.ownerId, target.memberId);
+      }
+    })
+  );
+}
+
+async function removeFromFriendPrivateProfile(userId: string, friendId: string) {
+  const profileRef = admin
+    .firestore()
+    .doc(`users/${friendId}/private/profile`);
+  const profileDoc = await profileRef.get();
+  if (!profileDoc.exists || !asStringArray(profileDoc.data()?.friends).includes(userId)) {
+    return;
+  }
+
+  await profileRef.update({
+    friends: admin.firestore.FieldValue.arrayRemove(userId),
+  });
+}
+
+async function removeMemberFromOwnedLists(ownerId: string, memberId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collection("lists")
+    .where("ownerId", "==", ownerId)
+    .get();
+
+  await removeMemberFromListDocs(snapshot.docs, memberId);
+}
+
+async function removeMemberFromDisplayLists(ownerId: string, memberId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collection("users")
+    .doc(ownerId)
+    .collection("displayLists")
+    .get();
+
+  await removeMemberFromListDocs(snapshot.docs, memberId);
+}
+
+async function removeMemberFromOwnedSchedules(ownerId: string, memberId: string) {
+  const snapshot = await admin
+    .firestore()
+    .collection("schedules")
+    .where("ownerId", "==", ownerId)
+    .where("visibleTo", "array-contains", memberId)
+    .get();
+
+  await removeMemberFromVisibleToDocs(snapshot.docs, memberId);
+}
+
+async function removeMemberFromListDocs(
+  docs: admin.firestore.QueryDocumentSnapshot[],
+  memberId: string
+) {
+  const targetDocs = docs.filter((doc) => asStringArray(doc.data().memberIds).includes(memberId));
+  if (targetDocs.length === 0) {
+    return;
+  }
+
+  const batch = admin.firestore().batch();
+  targetDocs.forEach((doc) => {
+    batch.update(doc.ref, {
+      memberIds: admin.firestore.FieldValue.arrayRemove(memberId),
+    });
+  });
+  await batch.commit();
+}
+
+async function removeMemberFromVisibleToDocs(
+  docs: admin.firestore.QueryDocumentSnapshot[],
+  memberId: string
+) {
+  if (docs.length === 0) {
+    return;
+  }
+
+  const batch = admin.firestore().batch();
+  docs.forEach((doc) => {
+    batch.update(doc.ref, {
+      visibleTo: admin.firestore.FieldValue.arrayRemove(memberId),
+    });
+  });
+  await batch.commit();
+}

--- a/functions/src/handlers/user/triggers.ts
+++ b/functions/src/handlers/user/triggers.ts
@@ -1,6 +1,10 @@
 import * as functions from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
 import { cleanupRetiredUserReferences } from "./deletion-cleanup";
+import {
+  getRemovedFriendIds,
+  mirrorRemovedFriendReferences,
+} from "./friend-sync";
 import { processUserUpdates } from "./batch-sync";
 import { buildUserProfileUpdates } from "./profile-sync";
 import { onScheduleDigestUserCreated } from "../schedule-digest/triggers";
@@ -71,6 +75,40 @@ export const onUserUpdate = functions.onDocumentUpdated(
     } catch (error) {
       console.error("ユーザー更新履歴記録エラー:", error);
       // エラーが発生してもトリガーは失敗させない
+    }
+  }
+);
+
+/**
+ * ユーザーが友達を削除した時に、相手側のfriends配列と双方のリストからも参照を外す。
+ */
+export const onPrivateProfileUpdate = functions.onDocumentUpdated(
+  {
+    document: "users/{userId}/private/profile",
+    region: "asia-northeast1",
+  },
+  async (event) => {
+    try {
+      const userId = event.params.userId;
+      const before = event.data?.before.data();
+      const after = event.data?.after.data();
+
+      if (!before || !after) {
+        console.log("プライベートプロフィールデータが存在しません");
+        return;
+      }
+
+      const removedFriendIds = getRemovedFriendIds(before, after);
+      if (removedFriendIds.length === 0) {
+        return;
+      }
+
+      await mirrorRemovedFriendReferences(userId, removedFriendIds);
+      console.log(
+        `友達削除の同期完了: ${userId}, removed=${removedFriendIds.join(",")}`
+      );
+    } catch (error) {
+      console.error("友達削除の同期エラー:", error);
     }
   }
 );

--- a/functions/src/notification-service.ts
+++ b/functions/src/notification-service.ts
@@ -122,6 +122,30 @@ function getErrorCode(error: unknown): string {
   return "unknown_error";
 }
 
+export function isExampleEmail(email: string | null | undefined): boolean {
+  return typeof email === "string" && email.toLowerCase().endsWith("@example.com");
+}
+
+async function shouldAutoAcceptFriendRequest(receiveUserId: string): Promise<boolean> {
+  try {
+    const userRecord = await admin.auth().getUser(receiveUserId);
+    return isExampleEmail(userRecord.email);
+  } catch (error) {
+    console.error("友達申請の自動承認判定に失敗しました:", error);
+    return false;
+  }
+}
+
+async function acceptFriendRequestAutomatically(
+  notificationRef: admin.firestore.DocumentReference
+) {
+  await notificationRef.update({
+    status: "accepted",
+    isRead: true,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+}
+
 async function getRecipientFcmTokens(
   receiveUserId: string,
   logContext: string
@@ -214,6 +238,19 @@ export const onNewFriendRequest = onDocumentCreated({
     // 友達申請通知かどうかを確認
     if (notification.type !== "friend") {
       console.log("友達申請以外の通知のため、処理をスキップします");
+      return;
+    }
+
+    if (notification.status !== "pending") {
+      console.log("保留中ではない友達申請のため、処理をスキップします");
+      return;
+    }
+
+    if (await shouldAutoAcceptFriendRequest(notification.receiveUserId)) {
+      await acceptFriendRequestAutomatically(snapshot.ref);
+      console.log(
+        `example.comアカウント宛の友達申請を自動承認しました: ${event.params.notificationId}`
+      );
       return;
     }
 

--- a/functions/src/test/friend-sync.test.ts
+++ b/functions/src/test/friend-sync.test.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import {
+  buildFriendRemovalCleanupTargets,
+  getRemovedFriendIds,
+} from "../handlers/user/friend-sync";
+
+describe("Friend Sync", () => {
+  describe("getRemovedFriendIds", () => {
+    it("returns friend ids removed from the private profile", () => {
+      const removedFriendIds = getRemovedFriendIds(
+        { friends: ["friend-a", "friend-b", "friend-c"] },
+        { friends: ["friend-a", "friend-c"] }
+      );
+
+      expect(removedFriendIds).to.deep.equal(["friend-b"]);
+    });
+
+    it("ignores added friend ids", () => {
+      const removedFriendIds = getRemovedFriendIds(
+        { friends: ["friend-a"] },
+        { friends: ["friend-a", "friend-b"] }
+      );
+
+      expect(removedFriendIds).to.deep.equal([]);
+    });
+  });
+
+  describe("buildFriendRemovalCleanupTargets", () => {
+    it("includes both users' friendship, schedules, public lists, and display lists", () => {
+      const targets = buildFriendRemovalCleanupTargets("user-a", "user-b");
+
+      expect(targets).to.deep.equal([
+        {
+          kind: "friendPrivateProfile",
+          userId: "user-a",
+          friendId: "user-b",
+        },
+        {
+          kind: "ownedLists",
+          ownerId: "user-a",
+          memberId: "user-b",
+        },
+        {
+          kind: "ownedLists",
+          ownerId: "user-b",
+          memberId: "user-a",
+        },
+        {
+          kind: "displayLists",
+          ownerId: "user-a",
+          memberId: "user-b",
+        },
+        {
+          kind: "displayLists",
+          ownerId: "user-b",
+          memberId: "user-a",
+        },
+        {
+          kind: "ownedSchedules",
+          ownerId: "user-a",
+          memberId: "user-b",
+        },
+        {
+          kind: "ownedSchedules",
+          ownerId: "user-b",
+          memberId: "user-a",
+        },
+      ]);
+    });
+  });
+});

--- a/functions/src/test/notification-service.test.ts
+++ b/functions/src/test/notification-service.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { isExampleEmail } from "../notification-service";
+
+describe("Notification Service", () => {
+  describe("isExampleEmail", () => {
+    it("returns true for example.com email addresses", () => {
+      expect(isExampleEmail("test@example.com")).to.equal(true);
+      expect(isExampleEmail("TEST@EXAMPLE.COM")).to.equal(true);
+    });
+
+    it("returns false for non-example.com email addresses", () => {
+      expect(isExampleEmail("test@example.jp")).to.equal(false);
+      expect(isExampleEmail(null)).to.equal(false);
+      expect(isExampleEmail(undefined)).to.equal(false);
+    });
+  });
+});

--- a/functions/src/test/user-triggers.test.ts
+++ b/functions/src/test/user-triggers.test.ts
@@ -28,4 +28,13 @@ describe("User Triggers", () => {
       expect(typeof onUserDeleted).to.equal("function");
     });
   });
+
+  describe("onPrivateProfileUpdate", () => {
+    it("should be importable", async () => {
+      const { onPrivateProfileUpdate } = await import("../handlers/user/triggers");
+
+      expect(onPrivateProfileUpdate).to.not.be.undefined;
+      expect(typeof onPrivateProfileUpdate).to.equal("function");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `@example.com` 宛の友達申請を Functions で自動承認する処理を追加
- private profile の friends 差分から友達削除を検知し、相手側 friends / 公開用リスト / 表示用リスト / 予定 visibleTo から参照を削除
- 友達削除同期と自動承認判定の unit test を追加

## Test Plan
- `npm run build`
- `npm run lint`
  - 既存 warning: `functions/src/handlers/user/batch-sync.ts:56:9 Forbidden non-null assertion`
- `npm run test:node20 -- --grep "Friend Sync|Notification Service|User Triggers"`
- dev Firebase deploy 済み
- Galaxy 実機 + dev Firebase で友達申請自動承認とフレンド削除同期を確認済み

## Related
- Flutter UI 側PRとセットで動作します
- Refs keishimizu26629/LaKiite-flutter-app#241
