### PR TITLE
[codex] Harden Firebase function cost guards

### DIFF
--- a/functions/src/handlers/auth/admin.ts
+++ b/functions/src/handlers/auth/admin.ts
@@ -1,0 +1,38 @@
+import * as admin from "firebase-admin";
+
+export class AdminAuthError extends Error {
+  constructor(
+    readonly status: number,
+    readonly response: { error: string }
+  ) {
+    super(response.error);
+  }
+}
+
+export function hasAdminClaim(
+  decodedToken: Record<string, unknown>
+): boolean {
+  return decodedToken.admin === true;
+}
+
+export async function verifyAdminAuthorizationHeader(
+  authHeader: string | string[] | undefined
+): Promise<admin.auth.DecodedIdToken> {
+  const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (!header || !header.startsWith("Bearer ")) {
+    throw new AdminAuthError(401, { error: "認証が必要です" });
+  }
+
+  let decodedToken: admin.auth.DecodedIdToken;
+  try {
+    decodedToken = await admin.auth().verifyIdToken(header.split("Bearer ")[1]);
+  } catch {
+    throw new AdminAuthError(401, { error: "無効なトークンです" });
+  }
+
+  if (!hasAdminClaim(decodedToken)) {
+    throw new AdminAuthError(403, { error: "管理者権限が必要です" });
+  }
+
+  return decodedToken;
+}

--- a/functions/src/handlers/list/manual-sync.ts
+++ b/functions/src/handlers/list/manual-sync.ts
@@ -1,5 +1,5 @@
 import * as functions from "firebase-functions/v2/https";
-import * as admin from "firebase-admin";
+import { AdminAuthError, verifyAdminAuthorizationHeader } from "../auth/admin";
 import { backfillAllScheduleVisibility } from "./utils";
 
 /**
@@ -30,14 +30,15 @@ export const backfillScheduleVisibility = functions.onRequest(
         return;
       }
 
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
-        res.status(401).send({ error: "認証が必要です" });
-        return;
+      try {
+        await verifyAdminAuthorizationHeader(req.headers.authorization);
+      } catch (error) {
+        if (error instanceof AdminAuthError) {
+          res.status(error.status).send(error.response);
+          return;
+        }
+        throw error;
       }
-
-      const token = authHeader.split("Bearer ")[1];
-      await admin.auth().verifyIdToken(token);
 
       const result = await backfillAllScheduleVisibility();
       res.status(200).send({

--- a/functions/src/handlers/list/utils.ts
+++ b/functions/src/handlers/list/utils.ts
@@ -1,5 +1,7 @@
 import * as admin from "firebase-admin";
 
+type ListDataCache = Map<string, admin.firestore.DocumentData | null>;
+
 /**
  * リストメンバー変更時に関連する予定の可視性を更新する。
  *
@@ -50,6 +52,7 @@ export async function backfillAllScheduleVisibility(): Promise<{
   let batch = db.batch();
   let batchCount = 0;
   let updated = 0;
+  const listCache: ListDataCache = new Map();
 
   for (const scheduleDoc of schedulesSnapshot.docs) {
     const scheduleData = scheduleDoc.data();
@@ -59,7 +62,7 @@ export async function backfillAllScheduleVisibility(): Promise<{
       continue;
     }
 
-    const nextVisibleTo = await calculateVisibleTo(scheduleData);
+    const nextVisibleTo = await calculateVisibleTo(scheduleData, listCache);
     const currentVisibleTo = asStringArray(scheduleData.visibleTo);
 
     if (!arraysEqual([...nextVisibleTo].sort(), [...currentVisibleTo].sort())) {
@@ -110,6 +113,7 @@ async function recomputeSchedulesVisibilityForList(
     let batch = db.batch();
     let batchCount = 0;
     let updatedCount = 0;
+    const listCache: ListDataCache = new Map();
 
     for (const scheduleDoc of schedulesSnapshot.docs) {
       const scheduleData = scheduleDoc.data();
@@ -118,7 +122,7 @@ async function recomputeSchedulesVisibilityForList(
         scheduleData,
         options.removeListId
       );
-      const newVisibleTo = await calculateVisibleTo(nextScheduleData);
+      const newVisibleTo = await calculateVisibleTo(nextScheduleData, listCache);
       const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
         visibleTo: newVisibleTo,
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -162,7 +166,8 @@ async function recomputeSchedulesVisibilityForList(
 }
 
 async function calculateVisibleTo(
-  scheduleData: admin.firestore.DocumentData
+  scheduleData: admin.firestore.DocumentData,
+  listCache: ListDataCache = new Map()
 ): Promise<string[]> {
   const db = admin.firestore();
   const ownerId = typeof scheduleData.ownerId === "string" ? scheduleData.ownerId : "";
@@ -174,13 +179,17 @@ async function calculateVisibleTo(
   }
 
   for (const sharedListId of sharedLists) {
-    const listDoc = await db.collection("lists").doc(sharedListId).get();
-    if (!listDoc.exists) {
+    if (!listCache.has(sharedListId)) {
+      const listDoc = await db.collection("lists").doc(sharedListId).get();
+      listCache.set(sharedListId, listDoc.exists ? listDoc.data() || {} : null);
+    }
+
+    const listData = listCache.get(sharedListId);
+    if (!listData) {
       console.warn(`Shared list not found: ${sharedListId}`);
       continue;
     }
 
-    const listData = listDoc.data() || {};
     for (const memberId of asStringArray(listData.memberIds)) {
       visibleTo.add(memberId);
     }

--- a/functions/src/handlers/schedule-digest/triggers.ts
+++ b/functions/src/handlers/schedule-digest/triggers.ts
@@ -19,8 +19,8 @@ export const sendMorningScheduleDigest = functions.onSchedule(
     schedule: "0 0-9 * * *",
     timeZone: "Asia/Tokyo",
     region: "asia-northeast1",
-    memory: "1GiB",
-    timeoutSeconds: 540,
+    memory: "256MiB",
+    timeoutSeconds: 120,
   },
   async () => {
     const notifyHour = getJstHour();

--- a/functions/src/handlers/user/manual-sync.ts
+++ b/functions/src/handlers/user/manual-sync.ts
@@ -1,6 +1,7 @@
 import * as functions from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
 import { processUserUpdates, UserUpdateData } from "./batch-sync";
+import { AdminAuthError, verifyAdminAuthorizationHeader } from "../auth/admin";
 
 /**
  * 手動でバッチ処理を実行するHTTPS関数
@@ -27,28 +28,17 @@ export const manualUserDataSync = functions.onRequest(
         return;
       }
 
-      // 管理者認証チェック
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
-        res.status(401).send({ error: "認証が必要です" });
-        return;
-      }
-
-      const token = authHeader.split("Bearer ")[1];
       let decodedToken;
-
       try {
-        decodedToken = await admin.auth().verifyIdToken(token);
+        decodedToken = await verifyAdminAuthorizationHeader(
+          req.headers.authorization
+        );
       } catch (error) {
-        res.status(401).send({ error: "無効なトークンです" });
-        return;
-      }
-
-      // 管理者権限チェック（実装は要件に応じて調整）
-      // 現在は全認証済みユーザーに許可（本番環境では制限を追加）
-      if (!decodedToken.uid) {
-        res.status(403).send({ error: "管理者権限が必要です" });
-        return;
+        if (error instanceof AdminAuthError) {
+          res.status(error.status).send(error.response);
+          return;
+        }
+        throw error;
       }
 
       console.log(`手動同期実行: ユーザー ${decodedToken.uid}`);
@@ -216,15 +206,15 @@ export const getUserDataSyncStatus = functions.onRequest(
         return;
       }
 
-      // 認証チェック
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
-        res.status(401).send({ error: "認証が必要です" });
-        return;
+      try {
+        await verifyAdminAuthorizationHeader(req.headers.authorization);
+      } catch (error) {
+        if (error instanceof AdminAuthError) {
+          res.status(error.status).send(error.response);
+          return;
+        }
+        throw error;
       }
-
-      const token = authHeader.split("Bearer ")[1];
-      await admin.auth().verifyIdToken(token);
 
       // 統計情報を取得
       const [pending, failed, processed] = await Promise.all([
@@ -232,16 +222,19 @@ export const getUserDataSyncStatus = functions.onRequest(
           .firestore()
           .collection("user_update_history")
           .where("isProcessed", "==", false)
+          .count()
           .get(),
         admin
           .firestore()
           .collection("user_update_history")
           .where("retryCount", ">=", 3)
+          .count()
           .get(),
         admin
           .firestore()
           .collection("user_update_history")
           .where("isProcessed", "==", true)
+          .count()
           .get(),
       ]);
 
@@ -254,10 +247,11 @@ export const getUserDataSyncStatus = functions.onRequest(
         .get();
 
       const status = {
-        pending: pending.size,
-        failed: failed.size,
-        processed: processed.size,
-        total: pending.size + failed.size + processed.size,
+        pending: pending.data().count,
+        failed: failed.data().count,
+        processed: processed.data().count,
+        total:
+          pending.data().count + failed.data().count + processed.data().count,
         lastBatchStats: latestStats.empty ? null : latestStats.docs[0].data(),
         timestamp: new Date().toISOString(),
       };

--- a/functions/src/handlers/user/monitoring.ts
+++ b/functions/src/handlers/user/monitoring.ts
@@ -29,6 +29,7 @@ export const batchProcessMonitoring = functions.onSchedule(
         .where("isProcessed", "==", false)
         .where("updatedAt", ">=", admin.firestore.Timestamp.fromDate(yesterday))
         .where("updatedAt", "<", admin.firestore.Timestamp.fromDate(today))
+        .count()
         .get();
 
       // 失敗した処理を確認
@@ -38,6 +39,7 @@ export const batchProcessMonitoring = functions.onSchedule(
         .where("retryCount", ">=", 3)
         .where("updatedAt", ">=", admin.firestore.Timestamp.fromDate(yesterday))
         .where("updatedAt", "<", admin.firestore.Timestamp.fromDate(today))
+        .count()
         .get();
 
       // 処理済みの履歴を確認
@@ -47,14 +49,19 @@ export const batchProcessMonitoring = functions.onSchedule(
         .where("isProcessed", "==", true)
         .where("updatedAt", ">=", admin.firestore.Timestamp.fromDate(yesterday))
         .where("updatedAt", "<", admin.firestore.Timestamp.fromDate(today))
+        .count()
         .get();
+
+      const unprocessedCount = unprocessedSnapshot.data().count;
+      const failedCount = failedSnapshot.data().count;
+      const processedCount = processedSnapshot.data().count;
 
       const stats = {
         date: yesterday.toISOString().split("T")[0],
-        unprocessedCount: unprocessedSnapshot.size,
-        failedCount: failedSnapshot.size,
-        processedCount: processedSnapshot.size,
-        totalCount: unprocessedSnapshot.size + failedSnapshot.size + processedSnapshot.size,
+        unprocessedCount,
+        failedCount,
+        processedCount,
+        totalCount: unprocessedCount + failedCount + processedCount,
       };
 
       console.log("バッチ処理統計:", stats);

--- a/functions/src/handlers/user/profile-sync.ts
+++ b/functions/src/handlers/user/profile-sync.ts
@@ -5,6 +5,8 @@ export interface UserProfileSnapshot {
   iconUrl?: string | null;
 }
 
+export const PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT = 500;
+
 export interface BuildUserProfileUpdatesInput {
   userId: string;
   before: UserProfileSnapshot;
@@ -171,6 +173,7 @@ async function updateCollectionGroupSnapshots(
     .firestore()
     .collectionGroup(collectionId)
     .where("userId", "==", userId)
+    .limit(PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT)
     .get();
 
   await commitBatches(snapshot.docs, (batch, doc) => {
@@ -191,6 +194,7 @@ async function updateScheduleOwnerSnapshots(
     .firestore()
     .collection("schedules")
     .where("ownerId", "==", userId)
+    .limit(PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT)
     .get();
 
   await commitBatches(snapshot.docs, (batch, doc) => {
@@ -207,8 +211,14 @@ async function updateNotificationSnapshots(
   }
 
   const [sentSnapshot, receivedSnapshot] = await Promise.all([
-    admin.firestore().collection("notifications").where("sendUserId", "==", userId).get(),
-    admin.firestore().collection("notifications").where("receiveUserId", "==", userId).get(),
+    admin.firestore().collection("notifications")
+      .where("sendUserId", "==", userId)
+      .limit(PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT)
+      .get(),
+    admin.firestore().collection("notifications")
+      .where("receiveUserId", "==", userId)
+      .limit(PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT)
+      .get(),
   ]);
   const docsById = new Map<string, admin.firestore.QueryDocumentSnapshot>();
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,7 +27,4 @@ export * from "./handlers/user/manual-sync";
 
 // 通知関連の関数をエクスポート
 export const sendNotification = notificationService.sendNotification;
-export const onNewFriendRequest = notificationService.onNewFriendRequest;
-export const onNewGroupInvitation = notificationService.onNewGroupInvitation;
-export const onNewReactionNotification = notificationService.onNewReactionNotification;
-export const onNewCommentNotification = notificationService.onNewCommentNotification;
+export const onNotificationCreated = notificationService.onNotificationCreated;

--- a/functions/src/notification-service.ts
+++ b/functions/src/notification-service.ts
@@ -2,6 +2,10 @@ import * as admin from "firebase-admin";
 import { onRequest } from "firebase-functions/v2/https";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { Request, Response } from "express";
+import {
+  AdminAuthError,
+  verifyAdminAuthorizationHeader,
+} from "./handlers/auth/admin";
 
 type MessageWithoutToken = Omit<admin.messaging.TokenMessage, "token">;
 
@@ -30,6 +34,16 @@ export const sendNotification = onRequest({
     if (req.method !== "POST") {
       res.status(405).send("Method Not Allowed");
       return;
+    }
+
+    try {
+      await verifyAdminAuthorizationHeader(req.headers.authorization);
+    } catch (error) {
+      if (error instanceof AdminAuthError) {
+        res.status(error.status).send(error.response);
+        return;
+      }
+      throw error;
     }
 
     const payload = req.body;
@@ -192,13 +206,7 @@ function maskFcmToken(token: string): string {
   return token.length <= 20 ? token : `${token.substring(0, 20)}...`;
 }
 
-/**
- * 新しい友達申請が作成された時に自動的にプッシュ通知を送信する
- *
- * 注意: このトリガーはnotificationsコレクションのすべてのドキュメント作成をキャッチするため、
- * 関数内で通知タイプのフィルタリングが必要です。
- */
-export const onNewFriendRequest = onDocumentCreated({
+export const onNotificationCreated = onDocumentCreated({
   region: "asia-northeast1",
   document: "notifications/{notificationId}"
 }, async (event) => {
@@ -211,305 +219,257 @@ export const onNewFriendRequest = onDocumentCreated({
 
     const notification = snapshot.data();
 
-    // 友達申請通知かどうかを確認
-    if (notification.type !== "friend") {
-      console.log("友達申請以外の通知のため、処理をスキップします");
+    switch (notification.type) {
+    case "friend":
+      await sendFriendRequestNotification(
+        event.params.notificationId,
+        notification
+      );
+      return;
+    case "groupInvitation":
+      await sendGroupInvitationNotification(
+        event.params.notificationId,
+        notification
+      );
+      return;
+    case "reaction":
+      await sendReactionNotification(event.params.notificationId, notification);
+      return;
+    case "comment":
+      await sendCommentNotification(event.params.notificationId, notification);
+      return;
+    default:
       return;
     }
-
-    const fcmTokens = await getRecipientFcmTokens(
-      notification.receiveUserId,
-      "友達申請通知"
-    );
-    if (fcmTokens.length === 0) {
-      return;
-    }
-
-    // 通知メッセージを作成
-    const message: MessageWithoutToken = {
-      notification: {
-        title: "友達申請が届きました",
-        body: `${notification.sendUserDisplayName || "新しいユーザー"}さんから友達申請が届いています`,
-      },
-      data: {
-        type: "friend_request",
-        notificationId: event.params.notificationId,
-        fromUserId: notification.sendUserId,
-        toUserId: notification.receiveUserId,
-        timestamp: Date.now().toString(),
-      },
-      android: {
-        notification: {
-          icon: "notification_icon",
-          color: "#ffa600",
-          clickAction: "FLUTTER_NOTIFICATION_CLICK",
-        },
-      },
-      apns: {
-        payload: {
-          aps: {
-            badge: 1,
-            sound: "default",
-          },
-        },
-      },
-    };
-
-    // 通知送信
-    await sendToFcmTokens(fcmTokens, message, "友達申請通知");
   } catch (error) {
-    console.error("友達申請通知送信エラー:", error);
+    console.error("通知作成トリガーエラー:", error);
   }
 });
 
-/**
- * 新しいグループ招待が作成された時に自動的にプッシュ通知を送信する
- */
-export const onNewGroupInvitation = onDocumentCreated({
-  region: "asia-northeast1",
-  document: "notifications/{notificationId}"
-}, async (event) => {
+async function sendFriendRequestNotification(
+  notificationId: string,
+  notification: admin.firestore.DocumentData
+): Promise<void> {
+  const fcmTokens = await getRecipientFcmTokens(
+    notification.receiveUserId,
+    "友達申請通知"
+  );
+  if (fcmTokens.length === 0) {
+    return;
+  }
+
+  const message: MessageWithoutToken = {
+    notification: {
+      title: "友達申請が届きました",
+      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんから友達申請が届いています`,
+    },
+    data: {
+      type: "friend_request",
+      notificationId,
+      fromUserId: notification.sendUserId,
+      toUserId: notification.receiveUserId,
+      timestamp: Date.now().toString(),
+    },
+    android: {
+      notification: {
+        icon: "notification_icon",
+        color: "#ffa600",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: {
+          badge: 1,
+          sound: "default",
+        },
+      },
+    },
+  };
+
+  await sendToFcmTokens(fcmTokens, message, "友達申請通知");
+}
+
+async function sendGroupInvitationNotification(
+  notificationId: string,
+  notification: admin.firestore.DocumentData
+): Promise<void> {
+  const fcmTokens = await getRecipientFcmTokens(
+    notification.receiveUserId,
+    "グループ招待通知"
+  );
+  if (fcmTokens.length === 0) {
+    return;
+  }
+
+  const groupDoc = await admin.firestore()
+    .collection("groups")
+    .doc(notification.groupId)
+    .get();
+
+  if (!groupDoc.exists) {
+    console.error("グループが存在しません:", notification.groupId);
+    return;
+  }
+
+  const groupData = groupDoc.data();
+  if (!groupData) {
+    console.error("グループデータが空です:", notification.groupId);
+    return;
+  }
+
+  const message: MessageWithoutToken = {
+    notification: {
+      title: "グループ招待が届きました",
+      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんから「${groupData.name}」グループへの招待が届いています`,
+    },
+    data: {
+      type: "group_invitation",
+      notificationId,
+      fromUserId: notification.sendUserId,
+      toUserId: notification.receiveUserId,
+      groupId: notification.groupId,
+      groupName: groupData.name,
+      timestamp: Date.now().toString(),
+    },
+    android: {
+      notification: {
+        icon: "notification_icon",
+        color: "#ffa600",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: {
+          badge: 1,
+          sound: "default",
+        },
+      },
+    },
+  };
+
+  await sendToFcmTokens(fcmTokens, message, "グループ招待通知");
+}
+
+async function sendReactionNotification(
+  notificationId: string,
+  notification: admin.firestore.DocumentData
+): Promise<void> {
+  const fcmTokens = await getRecipientFcmTokens(
+    notification.receiveUserId,
+    "リアクション通知"
+  );
+  if (fcmTokens.length === 0) {
+    return;
+  }
+
+  const message: MessageWithoutToken = {
+    notification: {
+      title: "新しいリアクション",
+      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にリアクションしました`,
+    },
+    data: {
+      type: "reaction",
+      notificationId,
+      fromUserId: notification.sendUserId,
+      toUserId: notification.receiveUserId,
+      relatedItemId: notification.relatedItemId,
+      interactionId: notification.interactionId,
+      timestamp: Date.now().toString(),
+    },
+    android: {
+      notification: {
+        icon: "notification_icon",
+        color: "#ffa600",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: {
+          badge: 1,
+          sound: "default",
+        },
+      },
+    },
+  };
+
+  await sendToFcmTokens(fcmTokens, message, "リアクション通知");
+}
+
+async function sendCommentNotification(
+  notificationId: string,
+  notification: admin.firestore.DocumentData
+): Promise<void> {
+  const fcmTokens = await getRecipientFcmTokens(
+    notification.receiveUserId,
+    "コメント通知"
+  );
+  if (fcmTokens.length === 0) {
+    return;
+  }
+
+  const commentContent = await getNotificationCommentContent(notification);
+
+  const message: MessageWithoutToken = {
+    notification: {
+      title: "新しいコメント",
+      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にコメントしました${commentContent ? ": " + commentContent : ""}`,
+    },
+    data: {
+      type: "comment",
+      notificationId,
+      fromUserId: notification.sendUserId,
+      toUserId: notification.receiveUserId,
+      relatedItemId: notification.relatedItemId,
+      interactionId: notification.interactionId,
+      commentContent,
+      timestamp: Date.now().toString(),
+    },
+    android: {
+      notification: {
+        icon: "notification_icon",
+        color: "#ffa600",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: {
+          badge: 1,
+          sound: "default",
+        },
+      },
+    },
+  };
+
+  await sendToFcmTokens(fcmTokens, message, "コメント通知");
+}
+
+async function getNotificationCommentContent(
+  notification: admin.firestore.DocumentData
+): Promise<string> {
+  if (!notification.interactionId) {
+    return "";
+  }
+
   try {
-    const snapshot = event.data;
-    if (!snapshot) {
-      console.log("データが存在しません");
-      return;
-    }
-
-    const notification = snapshot.data();
-
-    // グループ招待通知かどうかを確認
-    if (notification.type !== "groupInvitation") {
-      console.log("グループ招待以外の通知のため、処理をスキップします");
-      return;
-    }
-
-    const fcmTokens = await getRecipientFcmTokens(
-      notification.receiveUserId,
-      "グループ招待通知"
-    );
-    if (fcmTokens.length === 0) {
-      return;
-    }
-
-    // グループ情報を取得
-    const groupDoc = await admin.firestore()
-      .collection("groups")
-      .doc(notification.groupId)
+    const commentDoc = await admin.firestore()
+      .collection("schedules")
+      .doc(notification.relatedItemId)
+      .collection("comments")
+      .doc(notification.interactionId)
       .get();
 
-    if (!groupDoc.exists) {
-      console.error("グループが存在しません:", notification.groupId);
-      return;
+    const commentContent = commentDoc.data()?.content || "";
+    if (commentContent.length > 50) {
+      return `${commentContent.substring(0, 47)}...`;
     }
 
-    const groupData = groupDoc.data();
-    if (!groupData) {
-      console.error("グループデータが空です:", notification.groupId);
-      return;
-    }
-
-    // 通知メッセージを作成
-    const message: MessageWithoutToken = {
-      notification: {
-        title: "グループ招待が届きました",
-        body: `${notification.sendUserDisplayName || "新しいユーザー"}さんから「${groupData.name}」グループへの招待が届いています`,
-      },
-      data: {
-        type: "group_invitation",
-        notificationId: event.params.notificationId,
-        fromUserId: notification.sendUserId,
-        toUserId: notification.receiveUserId,
-        groupId: notification.groupId,
-        groupName: groupData.name,
-        timestamp: Date.now().toString(),
-      },
-      android: {
-        notification: {
-          icon: "notification_icon",
-          color: "#ffa600",
-          clickAction: "FLUTTER_NOTIFICATION_CLICK",
-        },
-      },
-      apns: {
-        payload: {
-          aps: {
-            badge: 1,
-            sound: "default",
-          },
-        },
-      },
-    };
-
-    // 通知送信
-    await sendToFcmTokens(fcmTokens, message, "グループ招待通知");
-  } catch (error) {
-    console.error("グループ招待通知送信エラー:", error);
+    return commentContent;
+  } catch (e) {
+    console.error("コメントデータ取得エラー:", e);
+    return "";
   }
-});
-
-/**
- * 新しいリアクション通知が作成された時に自動的にプッシュ通知を送信する
- */
-export const onNewReactionNotification = onDocumentCreated({
-  region: "asia-northeast1",
-  document: "notifications/{notificationId}"
-}, async (event) => {
-  try {
-    const snapshot = event.data;
-    if (!snapshot) {
-      console.log("データが存在しません");
-      return;
-    }
-
-    const notification = snapshot.data();
-
-    // リアクション通知かどうかを確認
-    if (notification.type !== "reaction") {
-      console.log("リアクション以外の通知のため、処理をスキップします");
-      return;
-    }
-
-    const fcmTokens = await getRecipientFcmTokens(
-      notification.receiveUserId,
-      "リアクション通知"
-    );
-    if (fcmTokens.length === 0) {
-      return;
-    }
-
-    // 通知メッセージを作成
-    const message: MessageWithoutToken = {
-      notification: {
-        title: "新しいリアクション",
-        body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にリアクションしました`,
-      },
-      data: {
-        type: "reaction",
-        notificationId: event.params.notificationId,
-        fromUserId: notification.sendUserId,
-        toUserId: notification.receiveUserId,
-        relatedItemId: notification.relatedItemId,
-        interactionId: notification.interactionId,
-        timestamp: Date.now().toString(),
-      },
-      android: {
-        notification: {
-          icon: "notification_icon",
-          color: "#ffa600",
-          clickAction: "FLUTTER_NOTIFICATION_CLICK",
-        },
-      },
-      apns: {
-        payload: {
-          aps: {
-            badge: 1,
-            sound: "default",
-          },
-        },
-      },
-    };
-
-    // 通知送信
-    await sendToFcmTokens(fcmTokens, message, "リアクション通知");
-  } catch (error) {
-    console.error("リアクション通知送信エラー:", error);
-  }
-});
-
-/**
- * 新しいコメント通知が作成された時に自動的にプッシュ通知を送信する
- */
-export const onNewCommentNotification = onDocumentCreated({
-  region: "asia-northeast1",
-  document: "notifications/{notificationId}"
-}, async (event) => {
-  try {
-    const snapshot = event.data;
-    if (!snapshot) {
-      console.log("データが存在しません");
-      return;
-    }
-
-    const notification = snapshot.data();
-
-    // コメント通知かどうかを確認
-    if (notification.type !== "comment") {
-      console.log("コメント以外の通知のため、処理をスキップします");
-      return;
-    }
-
-    const fcmTokens = await getRecipientFcmTokens(
-      notification.receiveUserId,
-      "コメント通知"
-    );
-    if (fcmTokens.length === 0) {
-      return;
-    }
-
-    // コメントのコンテンツを取得
-    let commentContent = "";
-    if (notification.interactionId) {
-      try {
-        const commentDoc = await admin.firestore()
-          .collection("schedules")
-          .doc(notification.relatedItemId)
-          .collection("comments")
-          .doc(notification.interactionId)
-          .get();
-
-        if (commentDoc.exists) {
-          const commentData = commentDoc.data();
-          if (commentData) {
-            commentContent = commentData.content || "";
-
-            // コメントが長すぎる場合はトリミング
-            if (commentContent.length > 50) {
-              commentContent = `${commentContent.substring(0, 47)}...`;
-            }
-          }
-        }
-      } catch (e) {
-        console.error("コメントデータ取得エラー:", e);
-      }
-    }
-
-    // 通知メッセージを作成
-    const message: MessageWithoutToken = {
-      notification: {
-        title: "新しいコメント",
-        body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にコメントしました${commentContent ? ": " + commentContent : ""}`,
-      },
-      data: {
-        type: "comment",
-        notificationId: event.params.notificationId,
-        fromUserId: notification.sendUserId,
-        toUserId: notification.receiveUserId,
-        relatedItemId: notification.relatedItemId,
-        interactionId: notification.interactionId,
-        commentContent: commentContent,
-        timestamp: Date.now().toString(),
-      },
-      android: {
-        notification: {
-          icon: "notification_icon",
-          color: "#ffa600",
-          clickAction: "FLUTTER_NOTIFICATION_CLICK",
-        },
-      },
-      apns: {
-        payload: {
-          aps: {
-            badge: 1,
-            sound: "default",
-          },
-        },
-      },
-    };
-
-    // 通知送信
-    await sendToFcmTokens(fcmTokens, message, "コメント通知");
-  } catch (error) {
-    console.error("コメント通知送信エラー:", error);
-  }
-});
+}

--- a/functions/src/test/admin-auth.test.ts
+++ b/functions/src/test/admin-auth.test.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import firebaseAdmin = require("firebase-admin");
+
+type AdminModule = {
+  auth?: () => {
+    verifyIdToken: (token: string) => Promise<Record<string, unknown>>;
+  };
+};
+
+function mockAdminAuth(
+  verifyIdToken: (token: string) => Promise<Record<string, unknown>>
+): () => void {
+  const adminModule = firebaseAdmin as unknown as AdminModule;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    adminModule,
+    "auth"
+  );
+
+  Object.defineProperty(adminModule, "auth", {
+    configurable: true,
+    value: () => ({ verifyIdToken }),
+  });
+
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(adminModule, "auth", originalDescriptor);
+    } else {
+      delete adminModule.auth;
+    }
+  };
+}
+
+describe("Admin auth helpers", () => {
+  describe("hasAdminClaim", () => {
+    it("only accepts an explicit admin true custom claim", async () => {
+      const { hasAdminClaim } = await import("../handlers/auth/admin");
+
+      expect(hasAdminClaim({ admin: true })).to.equal(true);
+      expect(hasAdminClaim({ admin: false })).to.equal(false);
+      expect(hasAdminClaim({ admin: "true" })).to.equal(false);
+      expect(hasAdminClaim({ uid: "user-1" })).to.equal(false);
+    });
+  });
+
+  describe("verifyAdminAuthorizationHeader", () => {
+    it("rejects missing bearer tokens", async () => {
+      const { AdminAuthError, verifyAdminAuthorizationHeader } = await import(
+        "../handlers/auth/admin"
+      );
+
+      try {
+        await verifyAdminAuthorizationHeader(undefined);
+        throw new Error("Expected auth to fail");
+      } catch (error) {
+        expect(error).to.be.instanceOf(AdminAuthError);
+        expect((error as InstanceType<typeof AdminAuthError>).status).to.equal(
+          401
+        );
+      }
+    });
+
+    it("rejects non-admin Firebase ID tokens", async () => {
+      const restoreAdminAuth = mockAdminAuth(async () => ({
+        uid: "user-1",
+        admin: false,
+      }));
+
+      try {
+        const { AdminAuthError, verifyAdminAuthorizationHeader } = await import(
+          "../handlers/auth/admin"
+        );
+
+        try {
+          await verifyAdminAuthorizationHeader("Bearer user-token");
+          throw new Error("Expected auth to fail");
+        } catch (error) {
+          expect(error).to.be.instanceOf(AdminAuthError);
+          expect(
+            (error as InstanceType<typeof AdminAuthError>).status
+          ).to.equal(403);
+        }
+      } finally {
+        restoreAdminAuth();
+      }
+    });
+
+    it("returns decoded tokens for admin Firebase ID tokens", async () => {
+      const restoreAdminAuth = mockAdminAuth(async (token) => ({
+        uid: "admin-user",
+        admin: token === "admin-token",
+      }));
+
+      try {
+        const { verifyAdminAuthorizationHeader } = await import(
+          "../handlers/auth/admin"
+        );
+
+        const decodedToken = await verifyAdminAuthorizationHeader(
+          "Bearer admin-token"
+        );
+
+        expect(decodedToken.uid).to.equal("admin-user");
+      } finally {
+        restoreAdminAuth();
+      }
+    });
+  });
+});

--- a/functions/src/test/manual-sync-status.test.ts
+++ b/functions/src/test/manual-sync-status.test.ts
@@ -1,0 +1,206 @@
+import { expect } from "chai";
+import firebaseAdmin = require("firebase-admin");
+
+type StatusRequest = Parameters<
+  typeof import("../handlers/user/manual-sync").getUserDataSyncStatus
+>[0];
+type StatusResponse = Parameters<
+  typeof import("../handlers/user/manual-sync").getUserDataSyncStatus
+>[1];
+
+type AdminModule = {
+  auth?: () => {
+    verifyIdToken: (token: string) => Promise<Record<string, unknown>>;
+  };
+  firestore?: () => {
+    collection: (name: string) => QueryMock;
+  };
+};
+
+type QueryMock = {
+  where: (field: string, operator: string, value: unknown) => QueryMock;
+  count: () => { get: () => Promise<{ data: () => { count: number } }> };
+  orderBy: (field: string, direction: string) => QueryMock;
+  limit: (limit: number) => QueryMock;
+  get: () => Promise<{
+    empty: boolean;
+    docs: { data: () => Record<string, unknown> }[];
+  }>;
+};
+
+type MockResponse = StatusResponse & {
+  statusCodeValue?: number;
+  body?: unknown;
+  headers: Record<string, string | string[]>;
+};
+
+function replaceAdminExport(
+  name: keyof AdminModule,
+  value: unknown
+): () => void {
+  const adminModule = firebaseAdmin as unknown as AdminModule;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    adminModule,
+    name
+  );
+
+  Object.defineProperty(adminModule, name, {
+    configurable: true,
+    value,
+  });
+
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(adminModule, name, originalDescriptor);
+    } else {
+      delete adminModule[name];
+    }
+  };
+}
+
+function mockAdminAuth(
+  verifyIdToken: (token: string) => Promise<Record<string, unknown>>
+): () => void {
+  return replaceAdminExport("auth", () => ({ verifyIdToken }));
+}
+
+function mockFirestoreForStatus(countCalls: string[]): () => void {
+  const countsByWhere = new Map<string, number>([
+    ["isProcessed == false", 4],
+    ["retryCount >= 3", 2],
+    ["isProcessed == true", 10],
+  ]);
+
+  const createQuery = (
+    collectionName: string,
+    whereCalls: string[] = []
+  ): QueryMock => ({
+    where: (field: string, operator: string, value: unknown) =>
+      createQuery(collectionName, [...whereCalls, `${field} ${operator} ${value}`]),
+    count: () => ({
+      get: async () => {
+        const whereKey = whereCalls.join(" && ");
+        countCalls.push(whereKey);
+        return { data: () => ({ count: countsByWhere.get(whereKey) ?? 0 }) };
+      },
+    }),
+    orderBy: () => createQuery(collectionName, whereCalls),
+    limit: () => createQuery(collectionName, whereCalls),
+    get: async () => ({
+      empty: false,
+      docs: [{ data: () => ({ processedUsers: 3, errors: 0 }) }],
+    }),
+  });
+
+  return replaceAdminExport("firestore", () => ({
+    collection: (name: string) => createQuery(name),
+  }));
+}
+
+function createResponse(): MockResponse {
+  const response = { headers: {} } as unknown as MockResponse;
+
+  response.on = () => response;
+  response.status = (code: number) => {
+    response.statusCodeValue = code;
+    return response;
+  };
+  response.send = (body: unknown) => {
+    response.body = body;
+    return response;
+  };
+  response.set = (name: string, value?: string | string[]) => {
+    response.headers[name] = value ?? "";
+    return response;
+  };
+  response.setHeader = (name: string, value: string | string[]) => {
+    response.headers[name] = value;
+    return response;
+  };
+  response.getHeader = (name: string) => response.headers[name];
+  response.end = (body?: unknown) => {
+    response.body = body;
+    return response;
+  };
+
+  return response;
+}
+
+describe("Manual user data sync status", () => {
+  it("rejects non-admin users before reading Firestore", async () => {
+    const restoreAdminAuth = mockAdminAuth(async () => ({
+      uid: "user-1",
+      admin: false,
+    }));
+    const countCalls: string[] = [];
+    const restoreFirestore = mockFirestoreForStatus(countCalls);
+
+    try {
+      const { getUserDataSyncStatus } = await import(
+        "../handlers/user/manual-sync"
+      );
+      const response = createResponse();
+
+      await getUserDataSyncStatus(
+        {
+          method: "GET",
+          headers: { authorization: "Bearer user-token" },
+        } as unknown as StatusRequest,
+        response
+      );
+
+      expect(response.statusCodeValue).to.equal(403);
+      expect(response.body).to.deep.equal({ error: "管理者権限が必要です" });
+      expect(countCalls).to.deep.equal([]);
+    } finally {
+      restoreFirestore();
+      restoreAdminAuth();
+    }
+  });
+
+  it("uses count aggregation and preserves the status response shape", async () => {
+    const restoreAdminAuth = mockAdminAuth(async () => ({
+      uid: "admin-user",
+      admin: true,
+    }));
+    const countCalls: string[] = [];
+    const restoreFirestore = mockFirestoreForStatus(countCalls);
+
+    try {
+      const { getUserDataSyncStatus } = await import(
+        "../handlers/user/manual-sync"
+      );
+      const response = createResponse();
+
+      await getUserDataSyncStatus(
+        {
+          method: "GET",
+          headers: { authorization: "Bearer admin-token" },
+        } as unknown as StatusRequest,
+        response
+      );
+
+      expect(countCalls).to.have.members([
+        "isProcessed == false",
+        "retryCount >= 3",
+        "isProcessed == true",
+      ]);
+      expect(response.statusCodeValue).to.equal(200);
+      expect(response.body).to.include({
+        pending: 4,
+        failed: 2,
+        processed: 10,
+        total: 16,
+      });
+      expect((response.body as Record<string, unknown>).lastBatchStats).to
+        .deep.equal({
+          processedUsers: 3,
+          errors: 0,
+        });
+      expect(response.body).to.have.property("timestamp");
+    } finally {
+      restoreFirestore();
+      restoreAdminAuth();
+    }
+  });
+});

--- a/functions/src/test/notification-service.test.ts
+++ b/functions/src/test/notification-service.test.ts
@@ -1,0 +1,447 @@
+import { expect } from "chai";
+import firebaseAdmin = require("firebase-admin");
+
+type SendNotificationRequest = Parameters<
+  typeof import("../notification-service").sendNotification
+>[0];
+type SendNotificationResponse = Parameters<
+  typeof import("../notification-service").sendNotification
+>[1];
+type NotificationCreatedEvent = Parameters<
+  typeof import("../notification-service").onNotificationCreated.run
+>[0];
+
+type AdminModule = {
+  auth?: () => {
+    verifyIdToken: (token: string) => Promise<Record<string, unknown>>;
+  };
+  firestore?: () => {
+    collection: (name: string) => CollectionMock;
+  };
+  messaging?: () => {
+    send: (message: Record<string, unknown>) => Promise<string>;
+    sendEach: (
+      messages: Record<string, unknown>[]
+    ) => Promise<{
+      successCount: number;
+      failureCount: number;
+      responses: { success: boolean }[];
+    }>;
+  };
+};
+
+type CollectionMock = {
+  doc: (id: string) => DocumentMock;
+};
+
+type DocumentMock = {
+  get: () => Promise<{
+    exists: boolean;
+    data: () => Record<string, unknown> | undefined;
+  }>;
+  collection: (name: string) => CollectionMock;
+};
+
+type MockResponse = SendNotificationResponse & {
+  statusCodeValue?: number;
+  body?: unknown;
+  headers: Record<string, string | string[]>;
+};
+
+function replaceAdminExport(
+  name: keyof AdminModule,
+  value: unknown
+): () => void {
+  const adminModule = firebaseAdmin as unknown as AdminModule;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    adminModule,
+    name
+  );
+
+  Object.defineProperty(adminModule, name, {
+    configurable: true,
+    value,
+  });
+
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(adminModule, name, originalDescriptor);
+    } else {
+      delete adminModule[name];
+    }
+  };
+}
+
+function mockAdminAuth(
+  verifyIdToken: (token: string) => Promise<Record<string, unknown>>
+): () => void {
+  return replaceAdminExport("auth", () => ({ verifyIdToken }));
+}
+
+function mockMessaging(
+  sentMessages: Record<string, unknown>[],
+  sentEachBatches: Record<string, unknown>[][]
+): () => void {
+  return replaceAdminExport("messaging", () => ({
+    send: async (message: Record<string, unknown>) => {
+      sentMessages.push(message);
+      return "mock-message-id";
+    },
+    sendEach: async (messages: Record<string, unknown>[]) => {
+      sentEachBatches.push(messages);
+      return {
+        successCount: messages.length,
+        failureCount: 0,
+        responses: messages.map(() => ({ success: true })),
+      };
+    },
+  }));
+}
+
+function mockFirestore(
+  documents: Record<string, Record<string, unknown>>
+): () => void {
+  const createCollection = (path: string[]): CollectionMock => ({
+    doc: (id: string) => createDocument([...path, id]),
+  });
+  const createDocument = (path: string[]): DocumentMock => ({
+    get: async () => {
+      const data = documents[path.join("/")];
+      return {
+        exists: data !== undefined,
+        data: () => data,
+      };
+    },
+    collection: (name: string) => createCollection([...path, name]),
+  });
+
+  return replaceAdminExport("firestore", () => ({
+    collection: (name: string) => createCollection([name]),
+  }));
+}
+
+function createResponse(): MockResponse {
+  const response = { headers: {} } as unknown as MockResponse;
+
+  response.on = () => response;
+  response.status = (code: number) => {
+    response.statusCodeValue = code;
+    return response;
+  };
+  response.send = (body: unknown) => {
+    response.body = body;
+    return response;
+  };
+  response.set = (name: string, value?: string | string[]) => {
+    response.headers[name] = value ?? "";
+    return response;
+  };
+  response.setHeader = (name: string, value: string | string[]) => {
+    response.headers[name] = value;
+    return response;
+  };
+  response.getHeader = (name: string) => response.headers[name];
+  response.end = (body?: unknown) => {
+    response.body = body;
+    return response;
+  };
+
+  return response;
+}
+
+function createNotificationEvent(
+  notificationId: string,
+  notification: Record<string, unknown>
+): NotificationCreatedEvent {
+  return {
+    params: { notificationId },
+    data: {
+      data: () => notification,
+    },
+  } as unknown as NotificationCreatedEvent;
+}
+
+describe("Notification service exports", () => {
+  it("uses one Firestore create trigger for notification dispatch", async () => {
+    const notificationService = await import("../notification-service");
+    const legacyExports = notificationService as Record<string, unknown>;
+
+    expect(notificationService.onNotificationCreated).to.not.be.undefined;
+    expect(legacyExports.onNewFriendRequest).to.equal(undefined);
+    expect(legacyExports.onNewGroupInvitation).to.equal(undefined);
+    expect(legacyExports.onNewReactionNotification).to.equal(undefined);
+    expect(legacyExports.onNewCommentNotification).to.equal(undefined);
+  });
+
+  describe("sendNotification", () => {
+    it("rejects requests without an admin bearer token", async () => {
+      const notificationService = await import("../notification-service");
+      const response = createResponse();
+
+      await notificationService.sendNotification(
+        {
+          method: "POST",
+          headers: {},
+          body: {
+            token: "fcm-token",
+            notification: { title: "title", body: "body" },
+            data: { type: "custom" },
+          },
+        } as unknown as SendNotificationRequest,
+        response
+      );
+
+      expect(response.statusCodeValue).to.equal(401);
+      expect(response.body).to.deep.equal({ error: "認証が必要です" });
+    });
+
+    it("rejects non-admin Firebase ID tokens before sending FCM", async () => {
+      const restoreAdminAuth = mockAdminAuth(async () => ({
+        uid: "user-1",
+        admin: false,
+      }));
+      const sentMessages: Record<string, unknown>[] = [];
+      const restoreMessaging = mockMessaging(sentMessages, []);
+
+      try {
+        const notificationService = await import("../notification-service");
+        const response = createResponse();
+
+        await notificationService.sendNotification(
+          {
+            method: "POST",
+            headers: { authorization: "Bearer user-token" },
+            body: {
+              token: "fcm-token",
+              notification: { title: "title", body: "body" },
+              data: { type: "custom" },
+            },
+          } as unknown as SendNotificationRequest,
+          response
+        );
+
+        expect(response.statusCodeValue).to.equal(403);
+        expect(response.body).to.deep.equal({ error: "管理者権限が必要です" });
+        expect(sentMessages).to.deep.equal([]);
+      } finally {
+        restoreMessaging();
+        restoreAdminAuth();
+      }
+    });
+
+    it("sends the same FCM payload for admin requests", async () => {
+      const restoreAdminAuth = mockAdminAuth(async () => ({
+        uid: "admin-user",
+        admin: true,
+      }));
+      const sentMessages: Record<string, unknown>[] = [];
+      const restoreMessaging = mockMessaging(sentMessages, []);
+
+      try {
+        const notificationService = await import("../notification-service");
+        const response = createResponse();
+
+        await notificationService.sendNotification(
+          {
+            method: "POST",
+            headers: { authorization: "Bearer admin-token" },
+            body: {
+              token: "fcm-token",
+              notification: { title: "title", body: "body" },
+              data: { type: "custom", customKey: "custom-value" },
+            },
+          } as unknown as SendNotificationRequest,
+          response
+        );
+
+        expect(response.statusCodeValue).to.equal(200);
+        expect(response.body).to.deep.equal({
+          success: true,
+          messageId: "mock-message-id",
+        });
+        expect(sentMessages).to.have.length(1);
+        expect(sentMessages[0]).to.include({
+          token: "fcm-token",
+        });
+        expect(sentMessages[0].notification).to.deep.equal({
+          title: "title",
+          body: "body",
+        });
+        expect(sentMessages[0].data).to.deep.equal({
+          type: "custom",
+          customKey: "custom-value",
+        });
+      } finally {
+        restoreMessaging();
+        restoreAdminAuth();
+      }
+    });
+  });
+
+  describe("onNotificationCreated", () => {
+    it("dispatches friend request notifications with the legacy payload", async () => {
+      const sentEachBatches: Record<string, unknown>[][] = [];
+      const restoreMessaging = mockMessaging([], sentEachBatches);
+      const restoreFirestore = mockFirestore({
+        "users/receive-user": {
+          fcmTokens: ["token-1", "token-1", "token-2", ""],
+        },
+      });
+
+      try {
+        const notificationService = await import("../notification-service");
+
+        await notificationService.onNotificationCreated.run(
+          createNotificationEvent("notification-1", {
+            type: "friend",
+            sendUserId: "send-user",
+            receiveUserId: "receive-user",
+            sendUserDisplayName: "送信者",
+          })
+        );
+
+        expect(sentEachBatches).to.have.length(1);
+        expect(sentEachBatches[0]).to.have.length(2);
+        expect(sentEachBatches[0][0].token).to.equal("token-1");
+        expect(sentEachBatches[0][1].token).to.equal("token-2");
+        expect(sentEachBatches[0][0].notification).to.deep.equal({
+          title: "友達申請が届きました",
+          body: "送信者さんから友達申請が届いています",
+        });
+        expect(sentEachBatches[0][0].data).to.include({
+          type: "friend_request",
+          notificationId: "notification-1",
+          fromUserId: "send-user",
+          toUserId: "receive-user",
+        });
+      } finally {
+        restoreFirestore();
+        restoreMessaging();
+      }
+    });
+
+    it("dispatches group invitation notifications with group details", async () => {
+      const sentEachBatches: Record<string, unknown>[][] = [];
+      const restoreMessaging = mockMessaging([], sentEachBatches);
+      const restoreFirestore = mockFirestore({
+        "users/receive-user": { fcmTokens: ["token-1"] },
+        "groups/group-1": { name: "テストグループ" },
+      });
+
+      try {
+        const notificationService = await import("../notification-service");
+
+        await notificationService.onNotificationCreated.run(
+          createNotificationEvent("notification-2", {
+            type: "groupInvitation",
+            sendUserId: "send-user",
+            receiveUserId: "receive-user",
+            sendUserDisplayName: "送信者",
+            groupId: "group-1",
+          })
+        );
+
+        expect(sentEachBatches).to.have.length(1);
+        expect(sentEachBatches[0][0].notification).to.deep.equal({
+          title: "グループ招待が届きました",
+          body: "送信者さんから「テストグループ」グループへの招待が届いています",
+        });
+        expect(sentEachBatches[0][0].data).to.include({
+          type: "group_invitation",
+          notificationId: "notification-2",
+          fromUserId: "send-user",
+          toUserId: "receive-user",
+          groupId: "group-1",
+          groupName: "テストグループ",
+        });
+      } finally {
+        restoreFirestore();
+        restoreMessaging();
+      }
+    });
+
+    it("dispatches reaction notifications with related item fields", async () => {
+      const sentEachBatches: Record<string, unknown>[][] = [];
+      const restoreMessaging = mockMessaging([], sentEachBatches);
+      const restoreFirestore = mockFirestore({
+        "users/receive-user": { fcmTokens: ["token-1"] },
+      });
+
+      try {
+        const notificationService = await import("../notification-service");
+
+        await notificationService.onNotificationCreated.run(
+          createNotificationEvent("notification-3", {
+            type: "reaction",
+            sendUserId: "send-user",
+            receiveUserId: "receive-user",
+            sendUserDisplayName: "送信者",
+            relatedItemId: "schedule-1",
+            interactionId: "reaction-1",
+          })
+        );
+
+        expect(sentEachBatches).to.have.length(1);
+        expect(sentEachBatches[0][0].notification).to.deep.equal({
+          title: "新しいリアクション",
+          body: "送信者さんがあなたの投稿にリアクションしました",
+        });
+        expect(sentEachBatches[0][0].data).to.include({
+          type: "reaction",
+          notificationId: "notification-3",
+          fromUserId: "send-user",
+          toUserId: "receive-user",
+          relatedItemId: "schedule-1",
+          interactionId: "reaction-1",
+        });
+      } finally {
+        restoreFirestore();
+        restoreMessaging();
+      }
+    });
+
+    it("dispatches comment notifications with truncated comment content", async () => {
+      const sentEachBatches: Record<string, unknown>[][] = [];
+      const restoreMessaging = mockMessaging([], sentEachBatches);
+      const restoreFirestore = mockFirestore({
+        "users/receive-user": { fcmTokens: ["token-1"] },
+        "schedules/schedule-1/comments/comment-1": {
+          content: "12345678901234567890123456789012345678901234567890more",
+        },
+      });
+
+      try {
+        const notificationService = await import("../notification-service");
+
+        await notificationService.onNotificationCreated.run(
+          createNotificationEvent("notification-4", {
+            type: "comment",
+            sendUserId: "send-user",
+            receiveUserId: "receive-user",
+            sendUserDisplayName: "送信者",
+            relatedItemId: "schedule-1",
+            interactionId: "comment-1",
+          })
+        );
+
+        expect(sentEachBatches).to.have.length(1);
+        expect(sentEachBatches[0][0].notification).to.deep.equal({
+          title: "新しいコメント",
+          body: "送信者さんがあなたの投稿にコメントしました: 12345678901234567890123456789012345678901234567...",
+        });
+        expect(sentEachBatches[0][0].data).to.include({
+          type: "comment",
+          notificationId: "notification-4",
+          fromUserId: "send-user",
+          toUserId: "receive-user",
+          relatedItemId: "schedule-1",
+          interactionId: "comment-1",
+          commentContent: "12345678901234567890123456789012345678901234567...",
+        });
+      } finally {
+        restoreFirestore();
+        restoreMessaging();
+      }
+    });
+  });
+});

--- a/functions/src/test/profile-sync.test.ts
+++ b/functions/src/test/profile-sync.test.ts
@@ -1,6 +1,16 @@
 import { expect } from "chai";
 
 describe("Profile Snapshot Sync", () => {
+  describe("PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT", () => {
+    it("should cap each snapshot sync query", async () => {
+      const { PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT } = await import(
+        "../handlers/user/profile-sync"
+      );
+
+      expect(PROFILE_SNAPSHOT_SYNC_QUERY_LIMIT).to.equal(500);
+    });
+  });
+
   describe("buildUserProfileUpdates", () => {
     it("should detect display name and icon url changes", async () => {
       const { buildUserProfileUpdates } = await import(


### PR DESCRIPTION
## Summary

- Add shared admin-claim authorization for manual/admin Firebase Functions
- Consolidate notification create triggers into `onNotificationCreated` while preserving friend/group/reaction/comment payloads
- Cap profile snapshot sync queries, use Firestore count aggregation, cache list reads, and reduce the morning digest resource allocation
- Add regression tests for admin auth, notification dispatch, manual sync status, and profile sync query limits

## Validation

- `npm run lint` passed with one existing warning in `functions/src/handlers/user/batch-sync.ts:56`
- `npm run test:node20` passed: 43 passing
- Deployed selected Functions to dev project `lakiite-flutter-app-dev`
- Verified dev Functions list includes `onNotificationCreated` and no longer includes the legacy notification triggers
- Android dev flavor smoke tested on `CPH2013` / `cf545991`
- Confirmed app logs: `env=development`, `projectId=lakiite-flutter-app-dev`
- Created a dev `notifications` smoke document and confirmed `onNotificationCreated` sent a comment notification to the device
- Deleted the smoke test notification document after verification

## Notes

- `onPrivateProfileUpdate` exists in dev but not in local source, so it was intentionally not deleted
- Dev logs showed stale FCM tokens returning `messaging/registration-token-not-registered`; token cleanup should be handled separately
- Android foreground local notification display hit `invalid_icon` for `notification_icon`; FCM receipt and processing worked, but the icon resource should be fixed separately
- Firebase deploy warns that Node.js 20 is deprecated and `firebase-functions` is outdated; Node 22 migration should be handled in a separate PR
