### PR TITLE
Allow appVersionV2 settings rules

### DIFF
--- a/scripts/set-app-version.js
+++ b/scripts/set-app-version.js
@@ -83,7 +83,7 @@ async function main() {
   const settings = buildSettings();
 
   console.log(`Project: ${projectId}`);
-  console.log('Document: settings/appVersion');
+  console.log('Documents: settings/appVersion, settings/appVersionV2');
   console.log(JSON.stringify(settings, null, 2));
 
   if (!shouldApply) {
@@ -93,8 +93,11 @@ async function main() {
 
   const admin = requireFirebaseAdmin();
   admin.initializeApp({projectId});
-  await admin.firestore().doc('settings/appVersion').set(settings, {merge: true});
-  console.log('settings/appVersion を更新しました。');
+  const batch = admin.firestore().batch();
+  batch.set(admin.firestore().doc('settings/appVersion'), settings, {merge: true});
+  batch.set(admin.firestore().doc('settings/appVersionV2'), settings, {merge: true});
+  await batch.commit();
+  console.log('settings/appVersion と settings/appVersionV2 を更新しました。');
 }
 
 main().catch((error) => {

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -162,17 +162,17 @@ service cloud.firestore {
     // settingsコレクションのルール
     match /settings/{settingId} {
       // 強制アップデート判定はログイン前にも必要なため公開読み取りを許可する。
-      allow read: if settingId == 'appVersion';
+      allow read: if settingId in ['appVersion', 'appVersionV2'];
 
       // 更新設定は管理者のみ書き込み可能。
       allow create, update: if request.auth != null
         && isAdmin()
-        && settingId == 'appVersion'
+        && settingId in ['appVersion', 'appVersionV2']
         && hasRequiredAppVersionFields(request.resource.data);
 
       allow delete: if request.auth != null
         && isAdmin()
-        && settingId == 'appVersion';
+        && settingId in ['appVersion', 'appVersionV2'];
     }
 
     match /scheduleDigestSettings/{userId} {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -32,6 +32,15 @@ describe('Settings Collection Security Rules', () => {
       await expectSuccess(db.doc('settings/appVersion').get());
     });
 
+    test('未認証ユーザーはappVersionV2を読み取れる', async () => {
+      const context = await setupTestEnvironment(null, {
+        'settings/appVersionV2': appVersionSettings()
+      });
+      const db = context.firestore();
+
+      await expectSuccess(db.doc('settings/appVersionV2').get());
+    });
+
     test('未認証ユーザーはappVersion以外のsettingsを読み取れない', async () => {
       const context = await setupTestEnvironment(null, {
         'settings/privateConfig': { value: 'secret' }
@@ -48,9 +57,13 @@ describe('Settings Collection Security Rules', () => {
       await expectFailure(
         db.doc('settings/appVersion').set(appVersionSettings())
       );
+
+      await expectFailure(
+        db.doc('settings/appVersionV2').set(appVersionSettings())
+      );
     });
 
-    test('管理者はappVersionを書き込める', async () => {
+    test('管理者はappVersionとappVersionV2を書き込める', async () => {
       const context = await setupTestEnvironment({
         uid: 'admin1',
         admin: true
@@ -59,6 +72,10 @@ describe('Settings Collection Security Rules', () => {
 
       await expectSuccess(
         db.doc('settings/appVersion').set(appVersionSettings())
+      );
+
+      await expectSuccess(
+        db.doc('settings/appVersionV2').set(appVersionSettings())
       );
     });
 
@@ -73,6 +90,10 @@ describe('Settings Collection Security Rules', () => {
 
       await expectFailure(
         db.doc('settings/appVersion').set(invalidSettings)
+      );
+
+      await expectFailure(
+        db.doc('settings/appVersionV2').set(invalidSettings)
       );
     });
   });


### PR DESCRIPTION
## Summary
- Allow public reads for both settings/appVersion and settings/appVersionV2
- Allow admins to manage both app version settings documents
- Update the app version script to write both documents for client compatibility

## Verification
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:/Users/keisukeshimizu/.nvm/versions/node/v25.9.0/bin:/Users/keisukeshimizu/.nvm/versions/node/v25.9.0/bin:/Users/keisukeshimizu/.nvm/versions/node/v25.9.0/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/keisukeshimizu/.codex/tmp/arg0/codex-arg0bDqIYL:/Users/keisukeshimizu/.local/share/mise/installs/npm-openai-codex/0.132.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/keisukeshimizu/.local/share/mise/installs/npm-openai-codex/0.132.0/bin:/Users/keisukeshimizu/bin:/Users/keisukeshimizu/google-cloud-sdk/bin:/Users/keisukeshimizu/.rbenv/shims:/usr/local/opt/grep/libexec/gnubin:/Users/keisukeshimizu/.tfenv/bin:/Users/keisukeshimizu/.rbenv/bin:/Users/keisukeshimizu/.pyenv/shims:/opt/homebrew/bin:/Users/keisukeshimizu/.nvm/versions/node/v25.9.0/bin:/Users/keisukeshimizu/.cargo/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/keisukeshimizu/.local/bin:/Users/keisukeshimizu/SDKs/flutter/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Users/keisukeshimizu/.pub-cache/bin:/Users/keisukeshimizu/Library/Android/sdk/platform-tools:/Users/keisukeshimizu/Library/Android/sdk/cmdline-tools/latest/bin:/Users/keisukeshimizu/.local/bin firebase emulators:exec --only firestore --project demo-test "npm test -- --runInBand tests/settings.test.js"
- npm run deploy:rules:dev
- Android dev app shows the force update dialog after restart