### PR TITLE
ci: allow Firebase deploy to delete stale functions

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Deploy Firebase resources
         run: |
           echo "🚀 Firebaseセキュリティルール、Functions、Indexesをデプロイ中..."
-          firebase deploy --only firestore:rules,storage,firestore:indexes,functions --project "$PROD_FIREBASE_PROJECT_ID"
+          firebase deploy --only firestore:rules,storage,firestore:indexes,functions --project "$PROD_FIREBASE_PROJECT_ID" --force
           echo "✅ デプロイが完了しました"
         env:
           PROD_FIREBASE_PROJECT_ID: ${{ vars.PROD_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Add `--force` to the production Firebase deploy command so CI can delete stale Functions that are no longer exported locally.

## Root cause
- The main deploy run failed after rules/indexes were deployed because Firebase CLI detected legacy production Functions that do not exist in the current source:
  - `onNewCommentNotification`
  - `onNewFriendRequest`
  - `onNewGroupInvitation`
  - `onNewReactionNotification`
- CI is non-interactive, so Firebase CLI aborted instead of confirming deletion.
- Current tests explicitly assert those legacy exports are absent and replaced by `onNotificationCreated`, so allowing deletion matches the source state.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/firestore-rules-test.yml`\n- `git diff --check`\n\nRefs #29