### PR TITLE
ci: allow Firebase deploy to delete stale functions

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Deploy Firebase resources
         run: |
           echo "🚀 Firebaseセキュリティルール、Functions、Indexesをデプロイ中..."
-          firebase deploy --only firestore:rules,storage,firestore:indexes,functions --project "$PROD_FIREBASE_PROJECT_ID"
+          firebase deploy --only firestore:rules,storage,firestore:indexes,functions --project "$PROD_FIREBASE_PROJECT_ID" --force
           echo "✅ デプロイが完了しました"
         env:
           PROD_FIREBASE_PROJECT_ID: ${{ vars.PROD_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Add `--force` to production Firebase deploy so CI can delete stale Functions no longer exported locally.

## Root cause
- Run 27061262398 failed in `deploy-firebase` after Firebase CLI detected legacy production Functions missing from current source and aborted in non-interactive mode.
- Current source and tests intentionally remove those legacy exports in favor of `onNotificationCreated`.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/firestore-rules-test.yml`\n- `git diff --check`\n\nRefs #29