### PR TITLE
feat: encrypted schedules の Firestore rules を追加する

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,7 +7,8 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^13.1.0",
-        "firebase-functions": "^6.3.1"
+        "firebase-functions": "^6.3.1",
+        "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
         "@types/chai": "^4.3.11",
@@ -9052,6 +9053,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -29,7 +29,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^13.1.0",
-    "firebase-functions": "^6.3.1"
+    "firebase-functions": "^6.3.1",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/functions/src/handlers/list/triggers.ts
+++ b/functions/src/handlers/list/triggers.ts
@@ -55,7 +55,8 @@ export const onListMemberUpdate = onDocumentUpdated({
  */
 export const onListDeleted = onDocumentDeleted({
   document: "lists/{listId}",
-  region: "asia-northeast1"
+  region: "asia-northeast1",
+  secrets: [scheduleMigrationPrivateKey],
 }, async (event) => {
   const listId = event.params.listId;
 

--- a/functions/src/handlers/list/triggers.ts
+++ b/functions/src/handlers/list/triggers.ts
@@ -1,4 +1,5 @@
 import { onDocumentDeleted, onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { scheduleMigrationPrivateKey } from "../schedule/encryption-migration";
 import { removeDeletedListFromSchedules, updateSchedulesVisibility } from "./utils";
 
 /**
@@ -6,7 +7,8 @@ import { removeDeletedListFromSchedules, updateSchedulesVisibility } from "./uti
  */
 export const onListMemberUpdate = onDocumentUpdated({
   document: "lists/{listId}",
-  region: "asia-northeast1"
+  region: "asia-northeast1",
+  secrets: [scheduleMigrationPrivateKey],
 }, async (event) => {
   const listId = event.params.listId;
   const beforeData = event.data?.before.data();

--- a/functions/src/handlers/list/utils.ts
+++ b/functions/src/handlers/list/utils.ts
@@ -103,6 +103,27 @@ export async function backfillAllScheduleVisibility(): Promise<{
   };
 }
 
+/**
+ * 単一予定の visibleTo / encryptedKeys / pending を sharedLists から正規化する。
+ * schedule 作成・更新時のサーバー生成派生データ更新に使う。
+ */
+export async function normalizeScheduleVisibilityForDocument(
+  scheduleRef: admin.firestore.DocumentReference<admin.firestore.DocumentData>,
+  scheduleData: admin.firestore.DocumentData
+): Promise<boolean> {
+  const updateData = await buildScheduleVisibilityUpdate({
+    scheduleData,
+    listCache: new Map(),
+  });
+
+  if (!shouldApplyScheduleVisibilityUpdate(scheduleData, updateData)) {
+    return false;
+  }
+
+  await scheduleRef.update(updateData);
+  return true;
+}
+
 async function recomputeSchedulesVisibilityForList(
   listId: string,
   options: { removeListId?: string } = {}
@@ -130,42 +151,14 @@ async function recomputeSchedulesVisibilityForList(
     for (const scheduleDoc of schedulesSnapshot.docs) {
       const scheduleData = scheduleDoc.data();
       const currentVisibleToArray = asStringArray(scheduleData.visibleTo);
-      const nextScheduleData = removeSharedListFromScheduleData(
+      const updateData = await buildScheduleVisibilityUpdate({
         scheduleData,
-        options.removeListId
-      );
-      const intendedVisibleTo = await calculateVisibleTo(
-        nextScheduleData,
-        listCache
-      );
-      const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
-        visibleTo: intendedVisibleTo,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      };
-
-      if (scheduleData.encrypted === true) {
-        Object.assign(
-          updateData,
-          await buildEncryptedScheduleAccessUpdate({
-            scheduleData,
-            intendedVisibleTo,
-            publicKeyCache: new Map(),
-            migrationSecretValue: readMigrationSecretValue(),
-          })
-        );
-      }
-
-      if (options.removeListId) {
-        updateData.sharedLists = admin.firestore.FieldValue.arrayRemove(
-          options.removeListId
-        );
-      }
+        listCache,
+        removeListId: options.removeListId,
+      });
 
       if (
-        !arraysEqual(
-          [...asStringArray(updateData.visibleTo)].sort(),
-          [...currentVisibleToArray].sort()
-        ) ||
+        shouldApplyScheduleVisibilityUpdate(scheduleData, updateData) ||
         options.removeListId
       ) {
         batch.update(scheduleDoc.ref, updateData);
@@ -195,6 +188,49 @@ async function recomputeSchedulesVisibilityForList(
   }
 }
 
+async function buildScheduleVisibilityUpdate({
+  scheduleData,
+  listCache,
+  removeListId,
+}: {
+  scheduleData: admin.firestore.DocumentData;
+  listCache: ListDataCache;
+  removeListId?: string;
+}): Promise<admin.firestore.UpdateData<admin.firestore.DocumentData>> {
+  const nextScheduleData = removeSharedListFromScheduleData(
+    scheduleData,
+    removeListId
+  );
+  const intendedVisibleTo = await calculateVisibleTo(
+    nextScheduleData,
+    listCache
+  );
+  const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
+    visibleTo: intendedVisibleTo,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+
+  if (nextScheduleData.encrypted === true) {
+    Object.assign(
+      updateData,
+      await buildEncryptedScheduleAccessUpdate({
+        scheduleData: nextScheduleData,
+        intendedVisibleTo,
+        publicKeyCache: new Map(),
+        migrationSecretValue: readMigrationSecretValue(),
+      })
+    );
+  }
+
+  if (removeListId) {
+    updateData.sharedLists = admin.firestore.FieldValue.arrayRemove(
+      removeListId
+    );
+  }
+
+  return updateData;
+}
+
 async function calculateVisibleTo(
   scheduleData: admin.firestore.DocumentData,
   listCache: ListDataCache = new Map()
@@ -217,6 +253,12 @@ async function calculateVisibleTo(
     const listData = listCache.get(sharedListId);
     if (!listData) {
       console.warn(`Shared list not found: ${sharedListId}`);
+      continue;
+    }
+    if (listData.ownerId !== ownerId) {
+      console.warn(
+        `Shared list ${sharedListId} is not owned by schedule owner ${ownerId}`
+      );
       continue;
     }
 
@@ -317,7 +359,7 @@ async function buildEncryptedScheduleAccessUpdate({
         },
       ])
     );
-  } else {
+  } else if (pendingUserIds.size === 0) {
     updateData.pendingEncryptedRecipientIds =
       admin.firestore.FieldValue.delete();
     updateData.pendingEncryptedRecipients = admin.firestore.FieldValue.delete();
@@ -391,6 +433,41 @@ function asScheduleEncryptedKey(value: unknown): ScheduleEncryptedKey | null {
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function shouldApplyScheduleVisibilityUpdate(
+  scheduleData: admin.firestore.DocumentData,
+  updateData: admin.firestore.UpdateData<admin.firestore.DocumentData>
+): boolean {
+  const currentVisibleTo = asStringArray(scheduleData.visibleTo).sort();
+  const nextVisibleTo = asStringArray(updateData.visibleTo).sort();
+
+  if (!arraysEqual(nextVisibleTo, currentVisibleTo)) {
+    return true;
+  }
+
+  if (Object.keys(updateData).some((key) => key.startsWith("encryptedKeys."))) {
+    return true;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(
+    updateData,
+    "pendingEncryptedRecipientIds"
+  )) {
+    const pendingUpdate = updateData.pendingEncryptedRecipientIds;
+    const currentPending = asStringArray(
+      scheduleData.pendingEncryptedRecipientIds
+    ).sort();
+
+    if (Array.isArray(pendingUpdate)) {
+      return !arraysEqual(asStringArray(pendingUpdate).sort(), currentPending);
+    }
+
+    return currentPending.length > 0 ||
+      Object.keys(asRecord(scheduleData.pendingEncryptedRecipients)).length > 0;
+  }
+
+  return false;
 }
 
 /**

--- a/functions/src/handlers/list/utils.ts
+++ b/functions/src/handlers/list/utils.ts
@@ -1,6 +1,18 @@
 import * as admin from "firebase-admin";
+import {
+  parseMigrationPrivateKeySecret,
+  rewrapMigrationEncryptedScheduleKey,
+  scheduleMigrationPrivateKey,
+  ScheduleEncryptedKey,
+} from "../schedule/encryption-migration";
 
 type ListDataCache = Map<string, admin.firestore.DocumentData | null>;
+type PublicKeyCache = Map<string, UserPublicKey | null>;
+
+type UserPublicKey = {
+  publicKey: string;
+  keyVersion: number;
+};
 
 /**
  * リストメンバー変更時に関連する予定の可視性を更新する。
@@ -122,11 +134,26 @@ async function recomputeSchedulesVisibilityForList(
         scheduleData,
         options.removeListId
       );
-      const newVisibleTo = await calculateVisibleTo(nextScheduleData, listCache);
+      const intendedVisibleTo = await calculateVisibleTo(
+        nextScheduleData,
+        listCache
+      );
       const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
-        visibleTo: newVisibleTo,
+        visibleTo: intendedVisibleTo,
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       };
+
+      if (scheduleData.encrypted === true) {
+        Object.assign(
+          updateData,
+          await buildEncryptedScheduleAccessUpdate({
+            scheduleData,
+            intendedVisibleTo,
+            publicKeyCache: new Map(),
+            migrationSecretValue: readMigrationSecretValue(),
+          })
+        );
+      }
 
       if (options.removeListId) {
         updateData.sharedLists = admin.firestore.FieldValue.arrayRemove(
@@ -135,14 +162,17 @@ async function recomputeSchedulesVisibilityForList(
       }
 
       if (
-        !arraysEqual([...newVisibleTo].sort(), [...currentVisibleToArray].sort()) ||
+        !arraysEqual(
+          [...asStringArray(updateData.visibleTo)].sort(),
+          [...currentVisibleToArray].sort()
+        ) ||
         options.removeListId
       ) {
         batch.update(scheduleDoc.ref, updateData);
         batchCount++;
         updatedCount++;
 
-        console.log(`Scheduled update for schedule ${scheduleDoc.id}: ${currentVisibleToArray.length} -> ${newVisibleTo.length} members`);
+        console.log(`Scheduled update for schedule ${scheduleDoc.id}: ${currentVisibleToArray.length} -> ${asStringArray(updateData.visibleTo).length} members`);
 
         if (batchCount >= 450) {
           await batch.commit();
@@ -222,6 +252,145 @@ function asStringArray(value: unknown): string[] {
   return value.filter((item): item is string => {
     return typeof item === "string" && item.length > 0;
   });
+}
+
+async function buildEncryptedScheduleAccessUpdate({
+  scheduleData,
+  intendedVisibleTo,
+  publicKeyCache,
+  migrationSecretValue,
+}: {
+  scheduleData: admin.firestore.DocumentData;
+  intendedVisibleTo: string[];
+  publicKeyCache: PublicKeyCache;
+  migrationSecretValue: string;
+}): Promise<admin.firestore.UpdateData<admin.firestore.DocumentData>> {
+  const encryptedKeys = asRecord(scheduleData.encryptedKeys);
+  const migrationEncryptedKeys = asRecord(scheduleData.migrationEncryptedKeys);
+  const visibleTo = new Set<string>();
+  const pendingUserIds = new Set<string>();
+  const encryptedKeyUpdates: Record<string, ScheduleEncryptedKey> = {};
+
+  const migrationSecret = migrationSecretValue
+    ? parseMigrationPrivateKeySecret(migrationSecretValue)
+    : null;
+  const migrationEncryptedKey = migrationSecret
+    ? asScheduleEncryptedKey(migrationEncryptedKeys[migrationSecret.keyId])
+    : null;
+
+  for (const userId of intendedVisibleTo) {
+    if (encryptedKeys[userId]) {
+      visibleTo.add(userId);
+      continue;
+    }
+
+    const publicKey = await getUserPublicKey(userId, publicKeyCache);
+    if (publicKey && migrationSecret && migrationEncryptedKey) {
+      encryptedKeyUpdates[`encryptedKeys.${userId}`] =
+        rewrapMigrationEncryptedScheduleKey({
+          migrationEncryptedKey,
+          migrationPrivateKey: migrationSecret.privateKey,
+          recipientPublicKey: publicKey.publicKey,
+          recipientKeyVersion: publicKey.keyVersion,
+        });
+      visibleTo.add(userId);
+      continue;
+    }
+
+    pendingUserIds.add(userId);
+  }
+
+  const updateData: admin.firestore.UpdateData<admin.firestore.DocumentData> = {
+    visibleTo: Array.from(visibleTo),
+    ...encryptedKeyUpdates,
+  };
+
+  if (pendingUserIds.size > 0 && migrationSecret) {
+    updateData.pendingEncryptedRecipientIds = Array.from(pendingUserIds);
+    updateData.pendingEncryptedRecipients = Object.fromEntries(
+      Array.from(pendingUserIds).map((userId) => [
+        userId,
+        {
+          reason: "missingPublicKey",
+          migrationKeyId: migrationSecret.keyId,
+          sharedListIds: asStringArray(scheduleData.sharedLists),
+        },
+      ])
+    );
+  } else {
+    updateData.pendingEncryptedRecipientIds =
+      admin.firestore.FieldValue.delete();
+    updateData.pendingEncryptedRecipients = admin.firestore.FieldValue.delete();
+  }
+
+  return updateData;
+}
+
+async function getUserPublicKey(
+  userId: string,
+  cache: PublicKeyCache
+): Promise<UserPublicKey | null> {
+  if (cache.has(userId)) {
+    return cache.get(userId) || null;
+  }
+
+  const doc = await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection("encryption")
+    .doc("current")
+    .get();
+  const data = doc.exists ? doc.data() || {} : {};
+  const publicKey =
+    typeof data.publicKey === "string" ? data.publicKey : "";
+  const value = publicKey
+    ? {
+      publicKey,
+      keyVersion: typeof data.keyVersion === "number" ? data.keyVersion : 1,
+    }
+    : null;
+  cache.set(userId, value);
+  return value;
+}
+
+function readMigrationSecretValue(): string {
+  try {
+    return scheduleMigrationPrivateKey.value();
+  } catch (error) {
+    console.warn("Schedule migration secret is unavailable:", error);
+    return "";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asScheduleEncryptedKey(value: unknown): ScheduleEncryptedKey | null {
+  const data = asRecord(value);
+  const encryptedScheduleKey = stringValue(data.encryptedScheduleKey);
+  const nonce = stringValue(data.nonce);
+  const mac = stringValue(data.mac);
+  const ephemeralPublicKey = stringValue(data.ephemeralPublicKey);
+  if (!encryptedScheduleKey || !nonce || !mac || !ephemeralPublicKey) {
+    return null;
+  }
+  return {
+    encryptedScheduleKey,
+    nonce,
+    mac,
+    ephemeralPublicKey,
+    algorithm: stringValue(data.algorithm) || "X25519+AES-GCM",
+    keyVersion: typeof data.keyVersion === "number" ? data.keyVersion : 1,
+  };
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 /**

--- a/functions/src/handlers/schedule/encryption-migration.ts
+++ b/functions/src/handlers/schedule/encryption-migration.ts
@@ -1,0 +1,274 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions/v2/firestore";
+import { defineSecret } from "firebase-functions/params";
+import nacl from "tweetnacl";
+
+export const scheduleMigrationPrivateKey = defineSecret(
+  "SCHEDULE_MIGRATION_PRIVATE_KEY"
+);
+
+export type ScheduleEncryptedKey = {
+  encryptedScheduleKey: string;
+  nonce: string;
+  mac: string;
+  ephemeralPublicKey: string;
+  algorithm: string;
+  keyVersion: number;
+};
+
+type MigrationPrivateKeySecret = {
+  keyId: string;
+  privateKey: string;
+  publicKey: string;
+  keyVersion: number;
+};
+
+type EncryptScheduleKeyParams = {
+  scheduleKey: Uint8Array;
+  recipientPublicKey: string;
+  keyVersion: number;
+};
+
+type DecryptScheduleKeyParams = {
+  encryptedKey: ScheduleEncryptedKey;
+  privateKey: string;
+};
+
+export function encryptScheduleKeyForPublicKey({
+  scheduleKey,
+  recipientPublicKey,
+  keyVersion,
+}: EncryptScheduleKeyParams): ScheduleEncryptedKey {
+  const recipientPublicKeyBytes = decodeBase64(recipientPublicKey, 32);
+  const ephemeralKeyPair = nacl.box.keyPair();
+  const sharedKey = nacl.scalarMult(
+    ephemeralKeyPair.secretKey,
+    recipientPublicKeyBytes
+  );
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", Buffer.from(sharedKey), nonce);
+  const cipherText = Buffer.concat([
+    cipher.update(Buffer.from(scheduleKey)),
+    cipher.final(),
+  ]);
+  const mac = cipher.getAuthTag();
+
+  return {
+    encryptedScheduleKey: cipherText.toString("base64"),
+    nonce: nonce.toString("base64"),
+    mac: mac.toString("base64"),
+    ephemeralPublicKey: Buffer.from(ephemeralKeyPair.publicKey).toString("base64"),
+    algorithm: "X25519+AES-GCM",
+    keyVersion,
+  };
+}
+
+export function decryptScheduleKey({
+  encryptedKey,
+  privateKey,
+}: DecryptScheduleKeyParams): Uint8Array {
+  const privateKeyBytes = decodeBase64(privateKey, 32);
+  const ephemeralPublicKey = decodeBase64(encryptedKey.ephemeralPublicKey, 32);
+  const sharedKey = nacl.scalarMult(privateKeyBytes, ephemeralPublicKey);
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    Buffer.from(sharedKey),
+    Buffer.from(encryptedKey.nonce, "base64")
+  );
+  decipher.setAuthTag(Buffer.from(encryptedKey.mac, "base64"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(encryptedKey.encryptedScheduleKey, "base64")),
+    decipher.final(),
+  ]);
+}
+
+export function rewrapMigrationEncryptedScheduleKey({
+  migrationEncryptedKey,
+  migrationPrivateKey,
+  recipientPublicKey,
+  recipientKeyVersion,
+}: {
+  migrationEncryptedKey: ScheduleEncryptedKey;
+  migrationPrivateKey: string;
+  recipientPublicKey: string;
+  recipientKeyVersion: number;
+}): ScheduleEncryptedKey {
+  const scheduleKey = decryptScheduleKey({
+    encryptedKey: migrationEncryptedKey,
+    privateKey: migrationPrivateKey,
+  });
+  return encryptScheduleKeyForPublicKey({
+    scheduleKey,
+    recipientPublicKey,
+    keyVersion: recipientKeyVersion,
+  });
+}
+
+export function parseMigrationPrivateKeySecret(
+  value: string
+): MigrationPrivateKeySecret {
+  const parsed = JSON.parse(value) as Partial<MigrationPrivateKeySecret>;
+  if (
+    typeof parsed.keyId !== "string" ||
+    typeof parsed.privateKey !== "string" ||
+    typeof parsed.publicKey !== "string"
+  ) {
+    throw new Error("Invalid schedule migration private key secret");
+  }
+  return {
+    keyId: parsed.keyId,
+    privateKey: parsed.privateKey,
+    publicKey: parsed.publicKey,
+    keyVersion: typeof parsed.keyVersion === "number" ? parsed.keyVersion : 1,
+  };
+}
+
+export async function grantPendingScheduleAccessForUser({
+  userId,
+  userPublicKey,
+  userKeyVersion,
+  migrationPrivateKeySecret,
+}: {
+  userId: string;
+  userPublicKey: string;
+  userKeyVersion: number;
+  migrationPrivateKeySecret: string;
+}): Promise<number> {
+  const migrationSecret = parseMigrationPrivateKeySecret(
+    migrationPrivateKeySecret
+  );
+  const db = admin.firestore();
+  const snapshot = await db
+    .collection("schedules")
+    .where("pendingEncryptedRecipientIds", "array-contains", userId)
+    .limit(500)
+    .get();
+
+  if (snapshot.empty) {
+    return 0;
+  }
+
+  let updated = 0;
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const scheduleDoc of snapshot.docs) {
+    const data = scheduleDoc.data();
+    if (data.encrypted !== true) {
+      continue;
+    }
+
+    const pendingRecipients = asRecord(data.pendingEncryptedRecipients);
+    const pendingRecipient = asRecord(pendingRecipients[userId]);
+    const migrationKeyId = stringValue(pendingRecipient.migrationKeyId);
+    const migrationEncryptedKeys = asRecord(data.migrationEncryptedKeys);
+    const migrationEncryptedKey = asScheduleEncryptedKey(
+      migrationEncryptedKeys[migrationKeyId]
+    );
+    if (!migrationEncryptedKey || migrationKeyId !== migrationSecret.keyId) {
+      console.warn(
+        `Cannot grant pending schedule ${scheduleDoc.id} to ${userId}: migration key is missing`
+      );
+      continue;
+    }
+
+    const recipientEncryptedKey = rewrapMigrationEncryptedScheduleKey({
+      migrationEncryptedKey,
+      migrationPrivateKey: migrationSecret.privateKey,
+      recipientPublicKey: userPublicKey,
+      recipientKeyVersion: userKeyVersion,
+    });
+
+    batch.update(scheduleDoc.ref, {
+      [`encryptedKeys.${userId}`]: recipientEncryptedKey,
+      [`pendingEncryptedRecipients.${userId}`]:
+        admin.firestore.FieldValue.delete(),
+      pendingEncryptedRecipientIds:
+        admin.firestore.FieldValue.arrayRemove(userId),
+      visibleTo: admin.firestore.FieldValue.arrayUnion(userId),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    batchCount++;
+    updated++;
+
+    if (batchCount >= 450) {
+      await batch.commit();
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  if (batchCount > 0) {
+    await batch.commit();
+  }
+
+  return updated;
+}
+
+export const onUserEncryptionKeyWritten = functions.onDocumentWritten(
+  {
+    document: "users/{userId}/encryption/current",
+    region: "asia-northeast1",
+    secrets: [scheduleMigrationPrivateKey],
+    timeoutSeconds: 540,
+  },
+  async (event) => {
+    const userId = event.params.userId;
+    const data = event.data?.after.data();
+    if (!data) {
+      return;
+    }
+
+    const publicKey = stringValue(data.publicKey);
+    if (!publicKey) {
+      return;
+    }
+
+    const updated = await grantPendingScheduleAccessForUser({
+      userId,
+      userPublicKey: publicKey,
+      userKeyVersion: typeof data.keyVersion === "number" ? data.keyVersion : 1,
+      migrationPrivateKeySecret: scheduleMigrationPrivateKey.value(),
+    });
+    console.log(`Granted ${updated} pending encrypted schedules to ${userId}`);
+  }
+);
+
+function asScheduleEncryptedKey(value: unknown): ScheduleEncryptedKey | null {
+  const data = asRecord(value);
+  const encryptedScheduleKey = stringValue(data.encryptedScheduleKey);
+  const nonce = stringValue(data.nonce);
+  const mac = stringValue(data.mac);
+  const ephemeralPublicKey = stringValue(data.ephemeralPublicKey);
+  if (!encryptedScheduleKey || !nonce || !mac || !ephemeralPublicKey) {
+    return null;
+  }
+  return {
+    encryptedScheduleKey,
+    nonce,
+    mac,
+    ephemeralPublicKey,
+    algorithm: stringValue(data.algorithm) || "X25519+AES-GCM",
+    keyVersion: typeof data.keyVersion === "number" ? data.keyVersion : 1,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function decodeBase64(value: string, expectedLength: number): Uint8Array {
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.length !== expectedLength) {
+    throw new Error(`Expected ${expectedLength} bytes, got ${bytes.length}`);
+  }
+  return bytes;
+}

--- a/functions/src/handlers/schedule/triggers.ts
+++ b/functions/src/handlers/schedule/triggers.ts
@@ -1,5 +1,42 @@
 import * as functions from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
+import { normalizeScheduleVisibilityForDocument } from "../list/utils";
+import { scheduleMigrationPrivateKey } from "./encryption-migration";
+
+/**
+ * スケジュール作成・更新時に sharedLists を正として visibleTo を正規化する。
+ * クライアントは owner のみを初期 visibleTo として保存し、リストメンバー展開と
+ * 暗号化予定の encryptedKeys / pending 更新はサーバー側で行う。
+ */
+export const onScheduleWritten = functions.onDocumentWritten({
+  document: "schedules/{scheduleId}",
+  region: "asia-northeast1",
+  secrets: [scheduleMigrationPrivateKey],
+}, async (event) => {
+  const after = event.data?.after;
+  const data = after?.data();
+  if (!after || !data) {
+    return null;
+  }
+
+  try {
+    const updated = await normalizeScheduleVisibilityForDocument(
+      after.ref,
+      data
+    );
+    if (updated) {
+      console.log(`Normalized schedule visibility: ${event.params.scheduleId}`);
+    }
+  } catch (error) {
+    console.error(
+      `Failed to normalize schedule visibility: ${event.params.scheduleId}`,
+      error
+    );
+    throw error;
+  }
+
+  return null;
+});
 
 /**
  * スケジュールのリアクションが追加されたときに自動的にカウンターを更新する

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,7 @@ export * from "./handlers/notification/triggers";
 
 // スケジュール関連のトリガーをエクスポート
 export * from "./handlers/schedule/triggers";
+export * from "./handlers/schedule/encryption-migration";
 export * from "./handlers/schedule-digest/triggers";
 export * from "./handlers/schedule-digest/manual-sync";
 

--- a/functions/src/notification-service.ts
+++ b/functions/src/notification-service.ts
@@ -456,12 +456,10 @@ async function sendCommentNotification(
     return;
   }
 
-  const commentContent = await getNotificationCommentContent(notification);
-
   const message: MessageWithoutToken = {
     notification: {
       title: "新しいコメント",
-      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にコメントしました${commentContent ? ": " + commentContent : ""}`,
+      body: `${notification.sendUserDisplayName || "新しいユーザー"}さんがあなたの投稿にコメントしました`,
     },
     data: {
       type: "comment",
@@ -470,7 +468,7 @@ async function sendCommentNotification(
       toUserId: notification.receiveUserId,
       relatedItemId: notification.relatedItemId,
       interactionId: notification.interactionId,
-      commentContent,
+      commentContent: "",
       timestamp: Date.now().toString(),
     },
     android: {
@@ -491,31 +489,4 @@ async function sendCommentNotification(
   };
 
   await sendToFcmTokens(fcmTokens, message, "コメント通知");
-}
-
-async function getNotificationCommentContent(
-  notification: admin.firestore.DocumentData
-): Promise<string> {
-  if (!notification.interactionId) {
-    return "";
-  }
-
-  try {
-    const commentDoc = await admin.firestore()
-      .collection("schedules")
-      .doc(notification.relatedItemId)
-      .collection("comments")
-      .doc(notification.interactionId)
-      .get();
-
-    const commentContent = commentDoc.data()?.content || "";
-    if (commentContent.length > 50) {
-      return `${commentContent.substring(0, 47)}...`;
-    }
-
-    return commentContent;
-  } catch (e) {
-    console.error("コメントデータ取得エラー:", e);
-    return "";
-  }
 }

--- a/functions/src/test/list-visibility-recompute.test.ts
+++ b/functions/src/test/list-visibility-recompute.test.ts
@@ -4,20 +4,24 @@ describe("List visibility recompute exports", () => {
   it("should export backfill and delete helpers", async () => {
     const {
       backfillAllScheduleVisibility,
+      normalizeScheduleVisibilityForDocument,
       removeDeletedListFromSchedules,
       updateSchedulesVisibility,
     } = await import("../handlers/list/utils");
 
     expect(backfillAllScheduleVisibility).to.be.a("function");
+    expect(normalizeScheduleVisibilityForDocument).to.be.a("function");
     expect(removeDeletedListFromSchedules).to.be.a("function");
     expect(updateSchedulesVisibility).to.be.a("function");
   });
 
-  it("should export list deleted trigger and manual backfill function", async () => {
+  it("should export list deleted trigger, schedule trigger, and manual backfill function", async () => {
     const { onListDeleted } = await import("../handlers/list/triggers");
+    const { onScheduleWritten } = await import("../handlers/schedule/triggers");
     const { backfillScheduleVisibility } = await import("../handlers/list/manual-sync");
 
     expect(onListDeleted).to.not.be.undefined;
+    expect(onScheduleWritten).to.not.be.undefined;
     expect(backfillScheduleVisibility).to.not.be.undefined;
   });
 });

--- a/functions/src/test/notification-service.test.ts
+++ b/functions/src/test/notification-service.test.ts
@@ -408,14 +408,11 @@ describe("Notification service exports", () => {
       }
     });
 
-    it("dispatches comment notifications with truncated comment content", async () => {
+    it("dispatches comment notifications without comment content", async () => {
       const sentEachBatches: Record<string, unknown>[][] = [];
       const restoreMessaging = mockMessaging([], sentEachBatches);
       const restoreFirestore = mockFirestore({
         "users/receive-user": { fcmTokens: ["token-1"] },
-        "schedules/schedule-1/comments/comment-1": {
-          content: "12345678901234567890123456789012345678901234567890more",
-        },
       });
 
       try {
@@ -435,7 +432,7 @@ describe("Notification service exports", () => {
         expect(sentEachBatches).to.have.length(1);
         expect(sentEachBatches[0][0].notification).to.deep.equal({
           title: "新しいコメント",
-          body: "送信者さんがあなたの投稿にコメントしました: 12345678901234567890123456789012345678901234567...",
+          body: "送信者さんがあなたの投稿にコメントしました",
         });
         expect(sentEachBatches[0][0].data).to.include({
           type: "comment",
@@ -444,7 +441,7 @@ describe("Notification service exports", () => {
           toUserId: "receive-user",
           relatedItemId: "schedule-1",
           interactionId: "comment-1",
-          commentContent: "12345678901234567890123456789012345678901234567...",
+          commentContent: "",
         });
       } finally {
         restoreFirestore();

--- a/functions/src/test/schedule-encryption-migration.test.ts
+++ b/functions/src/test/schedule-encryption-migration.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import nacl from "tweetnacl";
+import {
+  decryptScheduleKey,
+  encryptScheduleKeyForPublicKey,
+  rewrapMigrationEncryptedScheduleKey,
+} from "../handlers/schedule/encryption-migration";
+
+describe("schedule encryption migration", () => {
+  it("rewraps a migration encrypted schedule key for a recipient public key", () => {
+    const migrationKeyPair = nacl.box.keyPair();
+    const recipientKeyPair = nacl.box.keyPair();
+    const scheduleKey = nacl.randomBytes(32);
+
+    const migrationEncryptedKey = encryptScheduleKeyForPublicKey({
+      scheduleKey,
+      recipientPublicKey: Buffer.from(migrationKeyPair.publicKey).toString("base64"),
+      keyVersion: 1,
+    });
+
+    const recipientEncryptedKey = rewrapMigrationEncryptedScheduleKey({
+      migrationEncryptedKey,
+      migrationPrivateKey: Buffer.from(migrationKeyPair.secretKey).toString("base64"),
+      recipientPublicKey: Buffer.from(recipientKeyPair.publicKey).toString("base64"),
+      recipientKeyVersion: 1,
+    });
+
+    const decrypted = decryptScheduleKey({
+      encryptedKey: recipientEncryptedKey,
+      privateKey: Buffer.from(recipientKeyPair.secretKey).toString("base64"),
+    });
+
+    expect(Buffer.from(decrypted).equals(Buffer.from(scheduleKey))).to.equal(true);
+  });
+});

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -93,7 +93,24 @@ service cloud.firestore {
         && data.keyVersion is int
         && data.algorithm == 'X25519'
         && data.createdAt != null
-        && data.updatedAt != null;
+        && data.updatedAt != null
+        && (
+          !data.keys().hasAny(['encryptedPrivateKeyBackup'])
+          || hasValidPrivateKeyBackup(data.encryptedPrivateKeyBackup)
+        );
+    }
+
+    function hasValidPrivateKeyBackup(backup) {
+      return backup is map
+        && backup.cipherText is string
+        && backup.nonce is string
+        && backup.mac is string
+        && backup.algorithm == 'AES-GCM'
+        && backup.kdf == 'PBKDF2-HMAC-SHA256'
+        && backup.kdfIterations is int
+        && backup.salt is string
+        && backup.keyVersion is int
+        && backup.version is int;
     }
 
     // ユーザーがスケジュールにアクセス可能かを確認する関数

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -112,7 +112,6 @@ service cloud.firestore {
     function hasClientWritableEncryptedScheduleAccess(data) {
       return !data.keys().hasAny(['encrypted']) || data.encrypted != true || (
         data.encryptedKeys is map
-        && data.encryptedKeys.keys().hasOnly([request.auth.uid])
         && data.encryptedKeys.keys().hasAll([request.auth.uid])
         && hasValidEncryptedScheduleKey(data.encryptedKeys[request.auth.uid])
         && !data.keys().hasAny([
@@ -597,24 +596,40 @@ service cloud.firestore {
           && hasOptionalStringOrNull(request.resource.data, 'userPhotoUrl');
 
         // 更新: 自分のコメントのみ
-        allow update: if request.auth != null
-          && resource.data.userId == request.auth.uid
-          // userId の改ざんを防止
-          && request.resource.data.userId == resource.data.userId
-          // 更新可能なフィールドを制限
-          && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
-            'content',
-            'encrypted',
-            'encryptedContent',
-            'updatedAt',
-            'isEdited'
-          ])
-          && hasValidCommentContent(
-            get(/databases/$(database)/documents/schedules/$(scheduleId)).data,
-            request.resource.data
+        allow update: if request.auth != null && (
+          (
+            resource.data.userId == request.auth.uid
+            // userId の改ざんを防止
+            && request.resource.data.userId == resource.data.userId
+            // 更新可能なフィールドを制限
+            && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+              'content',
+              'encrypted',
+              'encryptedContent',
+              'updatedAt',
+              'isEdited'
+            ])
+            && hasValidCommentContent(
+              get(/databases/$(database)/documents/schedules/$(scheduleId)).data,
+              request.resource.data
+            )
+            && request.resource.data.updatedAt is timestamp
+            && request.resource.data.isEdited is bool
           )
-          && request.resource.data.updatedAt is timestamp
-          && request.resource.data.isEdited is bool;
+          || (
+            get(/databases/$(database)/documents/schedules/$(scheduleId)).data.ownerId == request.auth.uid
+            && request.resource.data.userId == resource.data.userId
+            && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+              'content',
+              'encrypted',
+              'encryptedContent'
+            ])
+            && hasValidCommentContent(
+              get(/databases/$(database)/documents/schedules/$(scheduleId)).data,
+              request.resource.data
+            )
+          )
+        );
 
         // 削除: 自分のコメントのみ
         allow delete: if request.auth != null && resource.data.userId == request.auth.uid;

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -58,13 +58,33 @@ service cloud.firestore {
       ) || (
         data.encrypted == true
         && data.encryptionVersion is int
-        && data.encryptedPayload is map
-        && data.encryptedPayload.cipherText is string
-        && data.encryptedPayload.nonce is string
-        && data.encryptedPayload.mac is string
-        && data.encryptedPayload.algorithm == 'AES-GCM'
+        && hasValidAesGcmPayload(data.encryptedPayload)
         && data.encryptedKeys is map
         && !data.keys().hasAny(['title', 'description', 'location'])
+      );
+    }
+
+    function hasValidAesGcmPayload(payload) {
+      return payload is map
+        && payload.cipherText is string
+        && payload.nonce is string
+        && payload.mac is string
+        && payload.algorithm == 'AES-GCM';
+    }
+
+    function hasValidCommentContent(scheduleData, data) {
+      return (
+        scheduleData.encrypted == true
+        && data.encrypted == true
+        && hasValidAesGcmPayload(data.encryptedContent)
+        && !data.keys().hasAny(['content'])
+      ) || (
+        (
+          !scheduleData.keys().hasAny(['encrypted']) ||
+          scheduleData.encrypted == false
+        )
+        && data.content is string
+        && !data.keys().hasAny(['encrypted', 'encryptedContent'])
       );
     }
 
@@ -458,6 +478,8 @@ service cloud.firestore {
           && request.resource.data.keys().hasOnly([
             'userId',
             'content',
+            'encrypted',
+            'encryptedContent',
             'createdAt',
             'updatedAt',
             'isEdited',
@@ -466,8 +488,10 @@ service cloud.firestore {
           ])
           // userId は自分自身でなければならない
           && request.resource.data.userId == request.auth.uid
-          // 必須フィールドの型チェック
-          && request.resource.data.content is string
+          && hasValidCommentContent(
+            get(/databases/$(database)/documents/schedules/$(scheduleId)).data,
+            request.resource.data
+          )
           && request.resource.data.createdAt is timestamp
           && request.resource.data.updatedAt is timestamp
           && request.resource.data.isEdited is bool
@@ -481,8 +505,17 @@ service cloud.firestore {
           // userId の改ざんを防止
           && request.resource.data.userId == resource.data.userId
           // 更新可能なフィールドを制限
-          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['content', 'updatedAt', 'isEdited'])
-          && request.resource.data.content is string
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+            'content',
+            'encrypted',
+            'encryptedContent',
+            'updatedAt',
+            'isEdited'
+          ])
+          && hasValidCommentContent(
+            get(/databases/$(database)/documents/schedules/$(scheduleId)).data,
+            request.resource.data
+          )
           && request.resource.data.updatedAt is timestamp
           && request.resource.data.isEdited is bool;
 

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -36,8 +36,7 @@ service cloud.firestore {
 
     // スケジュールの必須フィールドを確認する関数
     function hasRequiredScheduleFields(data) {
-      return data.title is string
-        && data.description is string
+      return hasValidScheduleDetails(data)
         && data.startDateTime != null
         && data.endDateTime != null
         && (!data.keys().hasAny(['isAllDay']) || data.isAllDay is bool)
@@ -47,6 +46,32 @@ service cloud.firestore {
         && data.ownerDisplayName is string
         && data.reactionCount is number
         && data.commentCount is number
+        && data.createdAt != null
+        && data.updatedAt != null;
+    }
+
+    function hasValidScheduleDetails(data) {
+      return (
+        data.title is string
+        && data.description is string
+        && hasOptionalStringOrNull(data, 'location')
+      ) || (
+        data.encrypted == true
+        && data.encryptionVersion is int
+        && data.encryptedPayload is map
+        && data.encryptedPayload.cipherText is string
+        && data.encryptedPayload.nonce is string
+        && data.encryptedPayload.mac is string
+        && data.encryptedPayload.algorithm == 'AES-GCM'
+        && data.encryptedKeys is map
+        && !data.keys().hasAny(['title', 'description', 'location'])
+      );
+    }
+
+    function hasRequiredEncryptionPublicKeyFields(data) {
+      return data.publicKey is string
+        && data.keyVersion is int
+        && data.algorithm == 'X25519'
         && data.createdAt != null
         && data.updatedAt != null;
     }
@@ -241,6 +266,20 @@ service cloud.firestore {
 
         allow delete: if request.auth != null
           && request.auth.uid == userId;
+      }
+
+      match /encryption/{docId} {
+        allow read: if request.auth != null
+          && docId == 'current';
+
+        allow create, update: if request.auth != null
+          && request.auth.uid == userId
+          && docId == 'current'
+          && hasRequiredEncryptionPublicKeyFields(request.resource.data);
+
+        allow delete: if request.auth != null
+          && request.auth.uid == userId
+          && docId == 'current';
       }
     }
 

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -72,6 +72,70 @@ service cloud.firestore {
         && payload.algorithm == 'AES-GCM';
     }
 
+    function hasValidEncryptedScheduleKey(encryptedKey) {
+      return encryptedKey is map
+        && encryptedKey.encryptedScheduleKey is string
+        && encryptedKey.nonce is string
+        && encryptedKey.mac is string
+        && encryptedKey.ephemeralPublicKey is string
+        && encryptedKey.algorithm == 'X25519+AES-GCM'
+        && encryptedKey.keyVersion is int;
+    }
+
+    function hasOwnerOnlyVisibleTo(data) {
+      return data.visibleTo is list
+        && data.visibleTo.size() == 1
+        && data.visibleTo[0] == request.auth.uid;
+    }
+
+    function ownsSharedList(listId) {
+      return listId is string
+        && exists(/databases/$(database)/documents/lists/$(listId))
+        && get(/databases/$(database)/documents/lists/$(listId)).data.ownerId == request.auth.uid;
+    }
+
+    function ownsAllSharedLists(sharedLists) {
+      return sharedLists is list
+        && sharedLists.size() <= 10
+        && (sharedLists.size() < 1 || ownsSharedList(sharedLists[0]))
+        && (sharedLists.size() < 2 || ownsSharedList(sharedLists[1]))
+        && (sharedLists.size() < 3 || ownsSharedList(sharedLists[2]))
+        && (sharedLists.size() < 4 || ownsSharedList(sharedLists[3]))
+        && (sharedLists.size() < 5 || ownsSharedList(sharedLists[4]))
+        && (sharedLists.size() < 6 || ownsSharedList(sharedLists[5]))
+        && (sharedLists.size() < 7 || ownsSharedList(sharedLists[6]))
+        && (sharedLists.size() < 8 || ownsSharedList(sharedLists[7]))
+        && (sharedLists.size() < 9 || ownsSharedList(sharedLists[8]))
+        && (sharedLists.size() < 10 || ownsSharedList(sharedLists[9]));
+    }
+
+    function hasClientWritableEncryptedScheduleAccess(data) {
+      return !data.keys().hasAny(['encrypted']) || data.encrypted != true || (
+        data.encryptedKeys is map
+        && data.encryptedKeys.keys().hasOnly([request.auth.uid])
+        && data.encryptedKeys.keys().hasAll([request.auth.uid])
+        && hasValidEncryptedScheduleKey(data.encryptedKeys[request.auth.uid])
+        && !data.keys().hasAny([
+          'pendingEncryptedRecipients',
+          'pendingEncryptedRecipientIds'
+        ])
+        && (
+          data.sharedLists.size() == 0
+          || (
+            data.migrationEncryptedKeys is map
+            && data.migrationEncryptedKeys.keys().hasOnly(['schedule-migration-v1'])
+            && hasValidEncryptedScheduleKey(data.migrationEncryptedKeys['schedule-migration-v1'])
+          )
+        )
+      );
+    }
+
+    function hasValidClientScheduleAccessFields(data) {
+      return hasOwnerOnlyVisibleTo(data)
+        && ownsAllSharedLists(data.sharedLists)
+        && hasClientWritableEncryptedScheduleAccess(data);
+    }
+
     function hasValidCommentContent(scheduleData, data) {
       return (
         scheduleData.encrypted == true
@@ -118,10 +182,7 @@ service cloud.firestore {
       return request.auth != null && (
         scheduleData.ownerId == request.auth.uid ||
         scheduleData.visibleTo.hasAny([request.auth.uid]) ||
-        (
-          scheduleData.sharedLists.size() > 0 &&
-          canAccessSharedList(scheduleData.sharedLists[0])
-        )
+        canAccessAnySharedList(scheduleData.sharedLists)
       );
     }
 
@@ -140,6 +201,22 @@ service cloud.firestore {
         listData.ownerId == request.auth.uid ||
         listData.memberIds.hasAny([request.auth.uid])
       );
+    }
+
+    function canAccessAnySharedList(sharedLists) {
+      return sharedLists is list
+        && (
+          (sharedLists.size() > 0 && canAccessSharedList(sharedLists[0])) ||
+          (sharedLists.size() > 1 && canAccessSharedList(sharedLists[1])) ||
+          (sharedLists.size() > 2 && canAccessSharedList(sharedLists[2])) ||
+          (sharedLists.size() > 3 && canAccessSharedList(sharedLists[3])) ||
+          (sharedLists.size() > 4 && canAccessSharedList(sharedLists[4])) ||
+          (sharedLists.size() > 5 && canAccessSharedList(sharedLists[5])) ||
+          (sharedLists.size() > 6 && canAccessSharedList(sharedLists[6])) ||
+          (sharedLists.size() > 7 && canAccessSharedList(sharedLists[7])) ||
+          (sharedLists.size() > 8 && canAccessSharedList(sharedLists[8])) ||
+          (sharedLists.size() > 9 && canAccessSharedList(sharedLists[9]))
+        );
     }
 
     function hasOptionalStringOrNull(data, field) {
@@ -440,6 +517,7 @@ service cloud.firestore {
       allow create: if request.auth != null
         && request.resource.data.ownerId == request.auth.uid
         && hasRequiredScheduleFields(request.resource.data)
+        && hasValidClientScheduleAccessFields(request.resource.data)
         && request.resource.data.reactionCount == 0
         && request.resource.data.commentCount == 0;
 
@@ -447,6 +525,8 @@ service cloud.firestore {
       allow update: if request.auth != null
         && resource.data.ownerId == request.auth.uid
         && hasRequiredScheduleFields(request.resource.data)
+        && request.resource.data.ownerId == resource.data.ownerId
+        && hasValidClientScheduleAccessFields(request.resource.data)
         && (
           // カウンターの更新を許可
           request.resource.data.reactionCount is number

--- a/security_rules/firestore/firestore.rules
+++ b/security_rules/firestore/firestore.rules
@@ -541,6 +541,11 @@ service cloud.firestore {
       }
     }
 
+    match /encryptionMigration/{docId} {
+      allow read: if request.auth != null && docId == 'current';
+      allow create, update, delete: if false;
+    }
+
     // notificationsコレクションのルール
     match /notifications/{notificationId} {
       // 必須フィールドの検証関数

--- a/tests/encryption_migration.test.js
+++ b/tests/encryption_migration.test.js
@@ -1,0 +1,64 @@
+const {
+  setupTestEnvironment,
+  teardownTestEnvironment,
+  expectSuccess,
+  expectFailure
+} = require('./helpers');
+
+describe('Encryption Migration Security Rules', () => {
+  afterEach(async () => {
+    await teardownTestEnvironment();
+  });
+
+  afterAll(async () => {
+    await teardownTestEnvironment();
+  });
+
+  test('認証済みユーザーは移行用公開鍵を読み取れる', async () => {
+    const context = await setupTestEnvironment(
+      { uid: 'user1' },
+      {
+        'encryptionMigration/current': {
+          keyId: 'schedule-migration-v1',
+          publicKey: 'base64-public-key',
+          keyVersion: 1,
+          algorithm: 'X25519',
+          enabled: true
+        }
+      }
+    );
+    const db = context.firestore();
+
+    await expectSuccess(db.doc('encryptionMigration/current').get());
+  });
+
+  test('未認証ユーザーは移行用公開鍵を読み取れない', async () => {
+    const context = await setupTestEnvironment(null, {
+      'encryptionMigration/current': {
+        keyId: 'schedule-migration-v1',
+        publicKey: 'base64-public-key',
+        keyVersion: 1,
+        algorithm: 'X25519',
+        enabled: true
+      }
+    });
+    const db = context.firestore();
+
+    await expectFailure(db.doc('encryptionMigration/current').get());
+  });
+
+  test('クライアントは移行用公開鍵を書き込めない', async () => {
+    const context = await setupTestEnvironment({ uid: 'user1' });
+    const db = context.firestore();
+
+    await expectFailure(
+      db.doc('encryptionMigration/current').set({
+        keyId: 'schedule-migration-v1',
+        publicKey: 'base64-public-key',
+        keyVersion: 1,
+        algorithm: 'X25519',
+        enabled: true
+      })
+    );
+  });
+});

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -137,7 +137,7 @@ describe('Schedules Collection Security Rules', () => {
         endDateTime: new Date(),
         ownerId: 'user1',
         sharedLists: [],
-        visibleTo: ['user1', 'user2'],
+        visibleTo: ['user1'],
         ownerDisplayName: 'Test User',
         reactionCount: 0,
         commentCount: 0,
@@ -157,14 +157,6 @@ describe('Schedules Collection Security Rules', () => {
             ephemeralPublicKey: 'ephemeral-public-key-1',
             algorithm: 'X25519+AES-GCM',
             keyVersion: 1
-          },
-          user2: {
-            encryptedScheduleKey: 'key-cipher-2',
-            nonce: 'key-nonce-2',
-            mac: 'key-mac-2',
-            ephemeralPublicKey: 'ephemeral-public-key-2',
-            algorithm: 'X25519+AES-GCM',
-            keyVersion: 1
           }
         },
         createdAt: new Date(),
@@ -176,8 +168,16 @@ describe('Schedules Collection Security Rules', () => {
       );
     });
 
-    test('認証済みユーザーは移行待ちユーザーを含む暗号化済みスケジュールを作成できる', async () => {
-      const context = await setupTestEnvironment({ uid: 'user1' });
+    test('認証済みユーザーは自分のリストを指定した暗号化済みスケジュールを作成できる', async () => {
+      const context = await setupTestEnvironment(
+        { uid: 'user1' },
+        {
+          'lists/list1': {
+            ownerId: 'user1',
+            memberIds: ['user2']
+          }
+        }
+      );
       const db = context.firestore();
 
       const scheduleData = {
@@ -217,14 +217,6 @@ describe('Schedules Collection Security Rules', () => {
             keyVersion: 1
           }
         },
-        pendingEncryptedRecipients: {
-          user2: {
-            reason: 'missingPublicKey',
-            migrationKeyId: 'schedule-migration-v1',
-            sharedListIds: ['list1']
-          }
-        },
-        pendingEncryptedRecipientIds: ['user2'],
         createdAt: new Date(),
         updatedAt: new Date()
       };
@@ -232,6 +224,58 @@ describe('Schedules Collection Security Rules', () => {
       await expectSuccess(
         db.doc('schedules/encryptedPendingSchedule').set(scheduleData)
       );
+    });
+
+    test('クライアントはvisibleToに他人を直接追加して作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      const scheduleData = {
+        title: 'New Schedule',
+        description: 'New Description',
+        startDateTime: new Date(),
+        endDateTime: new Date(),
+        ownerId: 'user1',
+        sharedLists: [],
+        visibleTo: ['user1', 'user2'],
+        ownerDisplayName: 'Test User',
+        reactionCount: 0,
+        commentCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      await expectFailure(db.doc('schedules/invalidVisibleTo').set(scheduleData));
+    });
+
+    test('他人のリストをsharedListsに指定して作成できない', async () => {
+      const context = await setupTestEnvironment(
+        { uid: 'user1' },
+        {
+          'lists/list2': {
+            ownerId: 'user2',
+            memberIds: ['user1']
+          }
+        }
+      );
+      const db = context.firestore();
+
+      const scheduleData = {
+        title: 'New Schedule',
+        description: 'New Description',
+        startDateTime: new Date(),
+        endDateTime: new Date(),
+        ownerId: 'user1',
+        sharedLists: ['list2'],
+        visibleTo: ['user1'],
+        ownerDisplayName: 'Test User',
+        reactionCount: 0,
+        commentCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      await expectFailure(db.doc('schedules/invalidSharedList').set(scheduleData));
     });
 
     test('暗号化済みスケジュールに平文詳細フィールドを混在できない', async () => {
@@ -343,7 +387,7 @@ describe('Schedules Collection Security Rules', () => {
           endDateTime: new Date(),
           ownerId: 'user1',
           sharedLists: [],
-          visibleTo: [],
+          visibleTo: ['user1'],
           ownerDisplayName: 'Test User',
           reactionCount: 0,
           commentCount: 0,

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -176,6 +176,64 @@ describe('Schedules Collection Security Rules', () => {
       );
     });
 
+    test('認証済みユーザーは移行待ちユーザーを含む暗号化済みスケジュールを作成できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      const scheduleData = {
+        startDateTime: new Date(),
+        endDateTime: new Date(),
+        ownerId: 'user1',
+        sharedLists: ['list1'],
+        visibleTo: ['user1'],
+        ownerDisplayName: 'Test User',
+        reactionCount: 0,
+        commentCount: 0,
+        encrypted: true,
+        encryptionVersion: 1,
+        encryptedPayload: {
+          cipherText: 'payload-cipher',
+          nonce: 'payload-nonce',
+          mac: 'payload-mac',
+          algorithm: 'AES-GCM'
+        },
+        encryptedKeys: {
+          user1: {
+            encryptedScheduleKey: 'key-cipher-1',
+            nonce: 'key-nonce-1',
+            mac: 'key-mac-1',
+            ephemeralPublicKey: 'ephemeral-public-key-1',
+            algorithm: 'X25519+AES-GCM',
+            keyVersion: 1
+          }
+        },
+        migrationEncryptedKeys: {
+          'schedule-migration-v1': {
+            encryptedScheduleKey: 'migration-key-cipher',
+            nonce: 'migration-key-nonce',
+            mac: 'migration-key-mac',
+            ephemeralPublicKey: 'migration-ephemeral-public-key',
+            algorithm: 'X25519+AES-GCM',
+            keyVersion: 1
+          }
+        },
+        pendingEncryptedRecipients: {
+          user2: {
+            reason: 'missingPublicKey',
+            migrationKeyId: 'schedule-migration-v1',
+            sharedListIds: ['list1']
+          }
+        },
+        pendingEncryptedRecipientIds: ['user2'],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      await expectSuccess(
+        db.doc('schedules/encryptedPendingSchedule').set(scheduleData)
+      );
+    });
+
     test('暗号化済みスケジュールに平文詳細フィールドを混在できない', async () => {
       const context = await setupTestEnvironment({ uid: 'user1' });
       const db = context.firestore();

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -128,6 +128,86 @@ describe('Schedules Collection Security Rules', () => {
       await expectSuccess(db.doc('schedules/newSchedule').set(scheduleData));
     });
 
+    test('認証済みユーザーは暗号化済みスケジュールを作成できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      const scheduleData = {
+        startDateTime: new Date(),
+        endDateTime: new Date(),
+        ownerId: 'user1',
+        sharedLists: [],
+        visibleTo: ['user1', 'user2'],
+        ownerDisplayName: 'Test User',
+        reactionCount: 0,
+        commentCount: 0,
+        encrypted: true,
+        encryptionVersion: 1,
+        encryptedPayload: {
+          cipherText: 'payload-cipher',
+          nonce: 'payload-nonce',
+          mac: 'payload-mac',
+          algorithm: 'AES-GCM'
+        },
+        encryptedKeys: {
+          user1: {
+            encryptedScheduleKey: 'key-cipher-1',
+            nonce: 'key-nonce-1',
+            mac: 'key-mac-1',
+            ephemeralPublicKey: 'ephemeral-public-key-1',
+            algorithm: 'X25519+AES-GCM',
+            keyVersion: 1
+          },
+          user2: {
+            encryptedScheduleKey: 'key-cipher-2',
+            nonce: 'key-nonce-2',
+            mac: 'key-mac-2',
+            ephemeralPublicKey: 'ephemeral-public-key-2',
+            algorithm: 'X25519+AES-GCM',
+            keyVersion: 1
+          }
+        },
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      await expectSuccess(
+        db.doc('schedules/encryptedSchedule').set(scheduleData)
+      );
+    });
+
+    test('暗号化済みスケジュールに平文詳細フィールドを混在できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      const invalidScheduleData = {
+        title: 'Plain title',
+        startDateTime: new Date(),
+        endDateTime: new Date(),
+        ownerId: 'user1',
+        sharedLists: [],
+        visibleTo: ['user1'],
+        ownerDisplayName: 'Test User',
+        reactionCount: 0,
+        commentCount: 0,
+        encrypted: true,
+        encryptionVersion: 1,
+        encryptedPayload: {
+          cipherText: 'payload-cipher',
+          nonce: 'payload-nonce',
+          mac: 'payload-mac',
+          algorithm: 'AES-GCM'
+        },
+        encryptedKeys: {},
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      await expectFailure(
+        db.doc('schedules/invalidEncryptedSchedule').set(invalidScheduleData)
+      );
+    });
+
     test('認証済みユーザーは終日スケジュールを作成できる', async () => {
       const context = await setupTestEnvironment({ uid: 'user1' });
       const db = context.firestore();

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -226,6 +226,66 @@ describe('Schedules Collection Security Rules', () => {
       );
     });
 
+    test('スケジュール所有者は複数ユーザー分のencryptedKeysへ更新できる', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          startDateTime: new Date(),
+          endDateTime: new Date(),
+          ownerId: 'user1',
+          sharedLists: [],
+          visibleTo: ['user1'],
+          ownerDisplayName: 'Test User',
+          reactionCount: 0,
+          commentCount: 0,
+          encrypted: true,
+          encryptionVersion: 1,
+          encryptedPayload: {
+            cipherText: 'payload-cipher',
+            nonce: 'payload-nonce',
+            mac: 'payload-mac',
+            algorithm: 'AES-GCM'
+          },
+          encryptedKeys: {
+            user1: {
+              encryptedScheduleKey: 'key-cipher-1',
+              nonce: 'key-nonce-1',
+              mac: 'key-mac-1',
+              ephemeralPublicKey: 'ephemeral-public-key-1',
+              algorithm: 'X25519+AES-GCM',
+              keyVersion: 1
+            }
+          },
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      };
+      const context = await setupTestEnvironment({ uid: 'user1' }, mockData);
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('schedules/schedule1').update({
+          encryptedKeys: {
+            user1: {
+              encryptedScheduleKey: 'key-cipher-1',
+              nonce: 'key-nonce-1',
+              mac: 'key-mac-1',
+              ephemeralPublicKey: 'ephemeral-public-key-1',
+              algorithm: 'X25519+AES-GCM',
+              keyVersion: 1
+            },
+            user2: {
+              encryptedScheduleKey: 'key-cipher-2',
+              nonce: 'key-nonce-2',
+              mac: 'key-mac-2',
+              ephemeralPublicKey: 'ephemeral-public-key-2',
+              algorithm: 'X25519+AES-GCM',
+              keyVersion: 1
+            }
+          }
+        })
+      );
+    });
+
     test('クライアントはvisibleToに他人を直接追加して作成できない', async () => {
       const context = await setupTestEnvironment({ uid: 'user1' });
       const db = context.firestore();
@@ -732,6 +792,44 @@ describe('Schedules Collection Security Rules', () => {
           },
           updatedAt: new Date(),
           isEdited: true
+        })
+      );
+    });
+
+    test('スケジュール所有者はre-keyのために暗号化コメント本文を更新できる', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          encrypted: true,
+          ownerId: 'user1',
+          visibleTo: ['user1', 'user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        },
+        'schedules/schedule1/comments/comment1': {
+          userId: 'user2',
+          encrypted: true,
+          encryptedContent,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isEdited: false
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user1' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectSuccess(
+        db.doc('schedules/schedule1/comments/comment1').update({
+          encryptedContent: {
+            cipherText: 'rekeyed-cipher',
+            nonce: 'rekeyed-nonce',
+            mac: 'rekeyed-mac',
+            algorithm: 'AES-GCM'
+          }
         })
       );
     });

--- a/tests/schedules.test.js
+++ b/tests/schedules.test.js
@@ -459,6 +459,13 @@ describe('Schedules Collection Security Rules', () => {
   });
 
   describe('コメント機能', () => {
+    const encryptedContent = {
+      cipherText: 'cipher',
+      nonce: 'nonce',
+      mac: 'mac',
+      algorithm: 'AES-GCM'
+    };
+
     test('認証済みユーザーはコメントを作成できる', async () => {
       const mockData = {
         'schedules/schedule1': {
@@ -478,6 +485,69 @@ describe('Schedules Collection Security Rules', () => {
 
       const db = context.firestore();
       await expectSuccess(
+        db.collection('schedules/schedule1/comments').add({
+          userId: 'user2',
+          content: 'Great schedule!',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isEdited: false,
+          userDisplayName: 'Test User 2',
+          userPhotoUrl: null
+        })
+      );
+    });
+
+    test('暗号化済みスケジュールでは暗号化コメントを作成できる', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          encrypted: true,
+          ownerId: 'user1',
+          visibleTo: ['user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectSuccess(
+        db.collection('schedules/schedule1/comments').add({
+          userId: 'user2',
+          encrypted: true,
+          encryptedContent,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isEdited: false,
+          userDisplayName: 'Test User 2',
+          userPhotoUrl: null
+        })
+      );
+    });
+
+    test('暗号化済みスケジュールでは平文コメントを作成できない', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          encrypted: true,
+          ownerId: 'user1',
+          visibleTo: ['user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectFailure(
         db.collection('schedules/schedule1/comments').add({
           userId: 'user2',
           content: 'Great schedule!',
@@ -518,6 +588,46 @@ describe('Schedules Collection Security Rules', () => {
       await expectSuccess(
         db.doc('schedules/schedule1/comments/comment1').update({
           content: 'Updated comment',
+          updatedAt: new Date(),
+          isEdited: true
+        })
+      );
+    });
+
+    test('暗号化コメントの作成者はencryptedContentを更新できる', async () => {
+      const mockData = {
+        'schedules/schedule1': {
+          encrypted: true,
+          ownerId: 'user1',
+          visibleTo: ['user2'],
+          sharedLists: [],
+          reactionCount: 0,
+          commentCount: 0
+        },
+        'schedules/schedule1/comments/comment1': {
+          userId: 'user2',
+          encrypted: true,
+          encryptedContent,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isEdited: false
+        }
+      };
+
+      const context = await setupTestEnvironment(
+        { uid: 'user2' },
+        mockData
+      );
+
+      const db = context.firestore();
+      await expectSuccess(
+        db.doc('schedules/schedule1/comments/comment1').update({
+          encryptedContent: {
+            cipherText: 'updated-cipher',
+            nonce: 'updated-nonce',
+            mac: 'updated-mac',
+            algorithm: 'AES-GCM'
+          },
           updatedAt: new Date(),
           isEdited: true
         })

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -257,6 +257,17 @@ describe('Users Collection Security Rules', () => {
       createdAt: new Date(),
       updatedAt: new Date()
     };
+    const encryptedPrivateKeyBackup = {
+      cipherText: 'encrypted-private-key',
+      nonce: 'nonce',
+      mac: 'mac',
+      algorithm: 'AES-GCM',
+      kdf: 'PBKDF2-HMAC-SHA256',
+      kdfIterations: 210000,
+      salt: 'salt',
+      keyVersion: 1,
+      version: 1
+    };
 
     test('認証済みユーザーは他ユーザーの公開鍵を読み取れる', async () => {
       const mockData = {
@@ -275,6 +286,32 @@ describe('Users Collection Security Rules', () => {
 
       await expectSuccess(
         db.doc('users/user1/encryption/current').set(publicKeyData)
+      );
+    });
+
+    test('ユーザーは自分の暗号化秘密鍵バックアップを保存できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('users/user1/encryption/current').set({
+          ...publicKeyData,
+          encryptedPrivateKeyBackup
+        })
+      );
+    });
+
+    test('ユーザーは平文秘密鍵バックアップを保存できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('users/user1/encryption/current').set({
+          ...publicKeyData,
+          encryptedPrivateKeyBackup: {
+            privateKey: 'plain-private-key'
+          }
+        })
       );
     });
 

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -248,4 +248,52 @@ describe('Users Collection Security Rules', () => {
       );
     });
   });
+
+  describe('暗号化公開鍵サブコレクション', () => {
+    const publicKeyData = {
+      publicKey: 'base64-public-key',
+      keyVersion: 1,
+      algorithm: 'X25519',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    test('認証済みユーザーは他ユーザーの公開鍵を読み取れる', async () => {
+      const mockData = {
+        'users/user1/encryption/current': publicKeyData
+      };
+
+      const context = await setupTestEnvironment({ uid: 'user2' }, mockData);
+      const db = context.firestore();
+
+      await expectSuccess(db.doc('users/user1/encryption/current').get());
+    });
+
+    test('ユーザーは自分の公開鍵を作成できる', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectSuccess(
+        db.doc('users/user1/encryption/current').set(publicKeyData)
+      );
+    });
+
+    test('ユーザーは他人の公開鍵を作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('users/user2/encryption/current').set(publicKeyData)
+      );
+    });
+
+    test('current以外の暗号化ドキュメントは作成できない', async () => {
+      const context = await setupTestEnvironment({ uid: 'user1' });
+      const db = context.firestore();
+
+      await expectFailure(
+        db.doc('users/user1/encryption/privateKeyBackups').set(publicKeyData)
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- 暗号化済み schedules の encryptedPayload / encryptedKeys 保存を許可しました
- users/{uid}/encryption/current の公開鍵 read/write rules を追加しました
- 暗号化済み schedule に平文詳細フィールドが混在しない rules test を追加しました

## Test Plan
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH firebase emulators:exec --only firestore --project demo-test "npm test -- --runInBand tests/schedules.test.js tests/users.test.js"
- git diff --check

Refs Inoworl/LaKiite-flutter-app#270